### PR TITLE
Fix review regressions: restore x402Pay and scan-before-expiry

### DIFF
--- a/app/lib/paywall/service.ts
+++ b/app/lib/paywall/service.ts
@@ -782,24 +782,6 @@ export async function refreshPaywallIntentStatus(
     return existing;
   }
 
-  const expiresAtMs = Date.parse(existing.expiresAt);
-  if (Number.isFinite(expiresAtMs) && nowMs > expiresAtMs) {
-    return mutatePaywallStore((store) => {
-      const intent = store.intents[intentId];
-      if (!intent) {
-        throw new PaywallError('NOT_FOUND', 'Intent not found.', 404);
-      }
-      if (intent.status === 'pending_payment') {
-        intent.status = 'expired';
-        pushEvent(store.payment_events, {
-          intent_id: intent.intent_id,
-          kind: 'expired',
-        });
-      }
-      return toIntentView(intent);
-    });
-  }
-
   const fromBlock = BigInt(existing.lastScannedBlock) + BigInt(1);
   let scan: Awaited<ReturnType<typeof scanIncomingTransfers>>;
   try {
@@ -902,6 +884,16 @@ export async function refreshPaywallIntentStatus(
         kind: 'settled',
         amount_raw: intent.paid_amount_raw,
       });
+    }
+    if (intent.status === 'pending_payment') {
+      const expiresAtMs = Date.parse(intent.expires_at);
+      if (Number.isFinite(expiresAtMs) && nowMs > expiresAtMs) {
+        intent.status = 'expired';
+        pushEvent(store.payment_events, {
+          intent_id: intent.intent_id,
+          kind: 'expired',
+        });
+      }
     }
 
     return toIntentView(intent);

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -36,7 +36,7 @@ import { dexscreenerProvider } from './providers/dexscreener.js';
 import { debridgeProvider } from './providers/debridge.js';
 import { fastTokenProvider } from './providers/fasttoken.js';
 import { omnisetProvider } from './providers/omniset.js';
-import { createFastTxExecutor } from './adapters/fast.js';
+import { createFastTxExecutor, rpcCall, SET_TOKEN_ID } from './adapters/fast.js';
 import { METHOD_SCHEMAS, schemaToParamString, schemaToParamDetails, schemaToResultString } from './schemas.js';
 import type {
   NetworkType,
@@ -91,6 +91,8 @@ import type {
   PaymentLinkResult,
   PaymentLinksParams,
   PaymentLinksResult,
+  X402PayParams,
+  X402PayResult,
 } from './types.js';
 
 import { parseUnits, formatUnits } from 'viem';
@@ -151,6 +153,8 @@ export type {
   PaymentLinksParams,
   PaymentLinksResult,
   PaymentLinkEntry,
+  X402PayParams,
+  X402PayResult,
 } from './types.js';
 
 export type {
@@ -272,6 +276,55 @@ function resolveSwapToken(token: string, chain: string): { address: string; deci
     chain,
     note: `Use a known symbol (USDC, USDT, WETH, WBTC, DAI) or pass a contract address directly.`,
   });
+}
+
+function resolveX402FastNetwork(network: string): NetworkType | null {
+  if (network === 'fastset-mainnet') return 'mainnet';
+  if (network === 'fastset-devnet' || network === 'fast') return 'testnet';
+  return null;
+}
+
+function tokenIdEquals(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+async function resolveFastTokenDisplay(
+  rpcUrl: string,
+  tokenId: Uint8Array,
+): Promise<{ symbol: string; decimals: number | null }> {
+  if (tokenIdEquals(tokenId, SET_TOKEN_ID)) {
+    return { symbol: 'SET', decimals: 18 };
+  }
+  try {
+    const metaResult = (await rpcCall(rpcUrl, 'proxy_getTokenInfo', {
+      token_ids: [tokenId],
+    })) as {
+      requested_token_metadata?: Array<[number[], {
+        token_name?: string;
+        decimals?: number;
+      } | null]>;
+    } | null;
+    const meta = metaResult?.requested_token_metadata?.[0]?.[1] ?? null;
+    if (meta && typeof meta.decimals === 'number') {
+      return {
+        symbol: meta.token_name ?? 'TOKEN',
+        decimals: meta.decimals,
+      };
+    }
+    if (meta?.token_name) {
+      return {
+        symbol: meta.token_name,
+        decimals: null,
+      };
+    }
+  } catch {
+    // Best effort: fall back to unknown token display below.
+  }
+  return { symbol: 'TOKEN', decimals: null };
 }
 
 
@@ -1481,6 +1534,187 @@ export const money = {
       note: entries.length === 0
         ? 'No payment links found. Create one: await money.createPaymentLink({ receiver: "...", amount: 10, chain: "fast" })'
         : `Found ${entries.length} payment link(s).`,
+    };
+  },
+
+  // ─── x402 payment ───────────────────────────────────────────────────────────
+
+  /**
+   * Pay for x402-protected content on FastSet.
+   * Automatically handles 402 Payment Required responses by:
+   * 1. Making initial request to get payment requirements
+   * 2. Creating and signing a TokenTransfer transaction on FastSet
+   * 3. Submitting the transaction to get a certificate
+   * 4. Retrying the request with X-PAYMENT header
+   */
+  async x402Pay(params: X402PayParams): Promise<X402PayResult> {
+    const { url, method = 'GET', headers: customHeaders = {}, body: requestBody } = params;
+
+    // Step 1: Make initial request to get 402 response
+    const initialRes = await fetch(url, {
+      method,
+      headers: customHeaders,
+      body: requestBody,
+    });
+
+    if (initialRes.status !== 402) {
+      // Not a 402, return the response as-is
+      const resHeaders: Record<string, string> = {};
+      initialRes.headers.forEach((v, k) => { resHeaders[k] = v; });
+      let resBody: unknown;
+      try {
+        resBody = await initialRes.json();
+      } catch {
+        resBody = await initialRes.text();
+      }
+      return {
+        success: initialRes.ok,
+        statusCode: initialRes.status,
+        headers: resHeaders,
+        body: resBody,
+        note: initialRes.ok ? 'Request succeeded without payment.' : `Request failed with status ${initialRes.status}.`,
+      };
+    }
+
+    // Step 2: Parse 402 response to get payment requirements
+    const paymentRequired = await initialRes.json() as {
+      x402Version?: number;
+      accepts?: Array<{
+        scheme: string;
+        network: string;
+        maxAmountRequired: string;
+        payTo: string;
+        asset?: string;
+      }>;
+    };
+
+    if (!paymentRequired.accepts || paymentRequired.accepts.length === 0) {
+      throw new MoneyError('INVALID_PARAMS', 'No payment requirements in 402 response', {
+        note: 'The server returned 402 but did not include payment requirements.',
+      });
+    }
+
+    // Find FastSet payment requirement
+    const fastsetReq = paymentRequired.accepts.find(r =>
+      r.network === 'fastset-devnet' || r.network === 'fastset-mainnet' || r.network === 'fast'
+    );
+
+    if (!fastsetReq) {
+      throw new MoneyError('UNSUPPORTED_OPERATION', 'No FastSet payment option available', {
+        note: `Available networks: ${paymentRequired.accepts.map(r => r.network).join(', ')}. Only FastSet is supported.`,
+      });
+    }
+
+    const resolvedNetwork = resolveX402FastNetwork(fastsetReq.network);
+    if (!resolvedNetwork) {
+      throw new MoneyError('UNSUPPORTED_OPERATION', `Unsupported FastSet network "${fastsetReq.network}"`, {
+        note: 'Supported FastSet networks: fastset-devnet, fastset-mainnet, fast.',
+      });
+    }
+
+    // Step 3: Ensure Fast chain is set up on matching network
+    const config = await loadConfig();
+    const fastKey = configKey('fast', resolvedNetwork);
+    const fastConfig = config.chains[fastKey];
+    if (!fastConfig) {
+      throw new MoneyError('CHAIN_NOT_CONFIGURED', 'Fast chain not configured', {
+        note: resolvedNetwork === 'mainnet'
+          ? 'Set up Fast mainnet first:\n  await money.setup({ chain: "fast", network: "mainnet" })'
+          : 'Set up Fast testnet first:\n  await money.setup({ chain: "fast" })',
+      });
+    }
+
+    // Step 4: Get buyer wallet address and create tx executor
+    const keyfilePath = expandHome(fastConfig.keyfile);
+    const kp = await loadKeyfile(keyfilePath);
+    const { bech32m } = await import('bech32');
+    const pubKeyBytes = Buffer.from(kp.publicKey, 'hex');
+    const words = bech32m.toWords(pubKeyBytes);
+    const buyerAddress = bech32m.encode('set', words, 90);
+
+    const rpcUrl = fastConfig.rpc;
+    const txExecutor = createFastTxExecutor(keyfilePath, rpcUrl, buyerAddress);
+
+    // Step 5: Parse token ID from asset
+    if (!fastsetReq.asset) {
+      throw new MoneyError('INVALID_PARAMS', 'Missing asset in 402 payment requirement', {
+        note: 'The server must include "accepts[].asset" (base64-encoded 32-byte token ID).',
+      });
+    }
+    const tokenId = new Uint8Array(Buffer.from(fastsetReq.asset, 'base64'));
+    if (tokenId.length !== 32) {
+      throw new MoneyError('INVALID_PARAMS', 'Invalid asset in 402 payment requirement', {
+        note: `Expected 32-byte token ID, got ${tokenId.length} bytes.`,
+      });
+    }
+
+    // Step 6: Create and submit TokenTransfer transaction
+    const { txHash, certificate } = await txExecutor.sendTokenTransfer(
+      fastsetReq.payTo,
+      fastsetReq.maxAmountRequired,
+      tokenId
+    );
+
+    // Step 7: Build x402 payment payload
+    const paymentPayload = {
+      x402Version: paymentRequired.x402Version ?? 1,
+      scheme: 'exact',
+      network: fastsetReq.network,
+      payload: {
+        type: 'signAndSendTransaction',
+        transactionCertificate: certificate,
+      },
+    };
+
+    const payloadBase64 = Buffer.from(JSON.stringify(paymentPayload)).toString('base64');
+
+    // Step 8: Retry request with X-PAYMENT header
+    const paidRes = await fetch(url, {
+      method,
+      headers: {
+        ...customHeaders,
+        'X-PAYMENT': payloadBase64,
+      },
+      body: requestBody,
+    });
+
+    const resHeaders: Record<string, string> = {};
+    paidRes.headers.forEach((v, k) => { resHeaders[k] = v; });
+
+    let resBody: unknown;
+    try {
+      resBody = await paidRes.json();
+    } catch {
+      resBody = await paidRes.text();
+    }
+
+    // Calculate human-readable amount (BigInt-safe)
+    const amountRaw = BigInt(fastsetReq.maxAmountRequired);
+    const tokenDisplay = await resolveFastTokenDisplay(rpcUrl, tokenId);
+    const amountHuman = tokenDisplay.decimals === null
+      ? amountRaw.toString()
+      : formatUnits(amountRaw, tokenDisplay.decimals);
+    const amountSummary = tokenDisplay.decimals === null
+      ? `${amountHuman} raw units (${tokenDisplay.symbol})`
+      : `${amountHuman} ${tokenDisplay.symbol}`;
+
+    return {
+      success: paidRes.ok,
+      statusCode: paidRes.status,
+      headers: resHeaders,
+      body: resBody,
+      payment: {
+        network: fastsetReq.network,
+        amount: amountHuman,
+        amountRaw: fastsetReq.maxAmountRequired,
+        decimals: tokenDisplay.decimals,
+        token: tokenDisplay.symbol,
+        recipient: fastsetReq.payTo,
+        txHash,
+      },
+      note: paidRes.ok
+        ? `Payment of ${amountSummary} successful. Content delivered.`
+        : `Payment submitted (tx: ${txHash}, ${amountSummary}) but server returned ${paidRes.status}.`,
     };
   },
 

--- a/sdk/src/schemas.ts
+++ b/sdk/src/schemas.ts
@@ -721,6 +721,41 @@ const listPaymentLinksMeta = {
   notes: 'Returns locally tracked payment links from ~/.money/payment-links.csv, newest first.',
 } as const;
 
+// ─── x402Pay ─────────────────────────────────────────────────────────────────
+
+export const X402PayParams = z.object({
+  url: z.string().describe('URL that returns 402 Payment Required'),
+  method: z.enum(['GET', 'POST', 'PUT', 'DELETE']).optional().describe('HTTP method (default: GET)'),
+  headers: z.record(z.string(), z.string()).optional().describe('Additional request headers'),
+  body: z.string().optional().describe('Request body for POST/PUT'),
+});
+
+export const X402PayResult = z.object({
+  success: z.boolean(),
+  statusCode: z.number(),
+  headers: z.record(z.string(), z.string()),
+  body: z.unknown(),
+  payment: z.object({
+    network: z.string(),
+    amount: z.string(),
+    amountRaw: z.string(),
+    decimals: z.number().nullable(),
+    token: z.string(),
+    recipient: z.string(),
+    txHash: z.string(),
+  }).optional(),
+  note: z.string(),
+});
+
+const x402PayMeta = {
+  description: 'Pay for x402-protected content on FastSet. Automatically handles 402 responses by creating payment, submitting to FastSet, and retrying with X-PAYMENT header.',
+  examples: [
+    'await money.x402Pay({ url: "https://api.example.com/premium" })',
+    'await money.x402Pay({ url: "https://api.example.com/data", method: "POST", body: JSON.stringify({ query: "..." }) })',
+  ],
+  notes: 'Supports fastset-devnet/testnet and fastset-mainnet/mainnet (legacy "fast" maps to testnet). The Fast chain must be set up on the matching network first. The 402 response must include accepts[].asset. Amount formatting uses token metadata when available; otherwise amount is returned in raw units.',
+} as const;
+
 // ─── Method schema entry ─────────────────────────────────────────────────────
 
 export interface MethodEntry {
@@ -775,6 +810,13 @@ export const METHOD_SCHEMAS: Record<string, MethodEntry> = {
     result: PaymentLinksResult,
     examples: [...listPaymentLinksMeta.examples],
     notes: listPaymentLinksMeta.notes,
+  },
+  x402Pay: {
+    description: x402PayMeta.description,
+    params: X402PayParams,
+    result: X402PayResult,
+    examples: [...x402PayMeta.examples],
+    notes: x402PayMeta.notes,
   },
 };
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -78,6 +78,12 @@ export type PaymentLinksParams = z.infer<typeof S.PaymentLinksParams>;
 /** Result of money.listPaymentLinks() */
 export type PaymentLinksResult = z.infer<typeof S.PaymentLinksResult>;
 
+/** Params for money.x402Pay() */
+export type X402PayParams = z.infer<typeof S.X402PayParams>;
+
+/** Result of money.x402Pay() */
+export type X402PayResult = z.infer<typeof S.X402PayResult>;
+
 /** Params for money.registerEvmChain() */
 export type RegisterEvmChainParams = z.infer<typeof S.RegisterEvmChainParams>;
 

--- a/sdk/tests/x402pay.test.ts
+++ b/sdk/tests/x402pay.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { money, MoneyError } from '../src/index.js';
+import { _resetAdapterCache } from '../src/registry.js';
+
+type FetchFn = typeof globalThis.fetch;
+
+const ORIGINAL_CONFIG_DIR = process.env.MONEY_CONFIG_DIR;
+const API_URL = 'https://paid.example.com/premium';
+const FAST_RPC_URL = 'https://proxy.fastset.xyz';
+const RECIPIENT = 'set1ld55rskkecy2wflhf0kmfr82ay937tpq7zwmx978udetmqqt2task3fcxc';
+
+let originalFetch: FetchFn;
+let tmpDir: string;
+
+function makeSetTokenId(): Uint8Array {
+  const tokenId = new Uint8Array(32);
+  tokenId.set([0xfa, 0x57, 0x5e, 0x70], 0);
+  return tokenId;
+}
+
+function toAssetBase64(tokenId: Uint8Array): string {
+  return Buffer.from(tokenId).toString('base64');
+}
+
+function getHeader(init: RequestInit | undefined, name: string): string | null {
+  const target = name.toLowerCase();
+  const headers = init?.headers;
+  if (!headers) return null;
+  if (Array.isArray(headers)) {
+    const found = headers.find(([k]) => k.toLowerCase() === target);
+    return found ? found[1] : null;
+  }
+  const maybeHeaders = headers as { get?: (header: string) => string | null };
+  if (typeof maybeHeaders.get === 'function') {
+    return maybeHeaders.get(name);
+  }
+  const headerMap = headers as Record<string, string>;
+  for (const [k, v] of Object.entries(headerMap)) {
+    if (k.toLowerCase() === target) return v;
+  }
+  return null;
+}
+
+function rpcResponse(result: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => ({ jsonrpc: '2.0', id: 1, result }),
+    text: async () => JSON.stringify({ jsonrpc: '2.0', id: 1, result }),
+  } as Response;
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'money-x402-test-'));
+  process.env.MONEY_CONFIG_DIR = tmpDir;
+  originalFetch = globalThis.fetch;
+  _resetAdapterCache();
+});
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  if (ORIGINAL_CONFIG_DIR === undefined) {
+    delete process.env.MONEY_CONFIG_DIR;
+  } else {
+    process.env.MONEY_CONFIG_DIR = ORIGINAL_CONFIG_DIR;
+  }
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('money.x402Pay', () => {
+  it('uses Fast mainnet config when server requests fastset-mainnet', async () => {
+    const setTokenId = makeSetTokenId();
+    const setAsset = toAssetBase64(setTokenId);
+    const rpcMethods: string[] = [];
+    let apiCalls = 0;
+
+    await money.setup({ chain: 'fast', network: 'mainnet' });
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlString = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+
+      if (urlString === API_URL) {
+        apiCalls += 1;
+        const xPayment = getHeader(init, 'X-PAYMENT');
+        if (!xPayment) {
+          const body = {
+            x402Version: 1,
+            accepts: [{
+              scheme: 'exact',
+              network: 'fastset-mainnet',
+              maxAmountRequired: '1000000000000000000',
+              payTo: RECIPIENT,
+              asset: setAsset,
+            }],
+          };
+          return {
+            ok: false,
+            status: 402,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: async () => body,
+            text: async () => JSON.stringify(body),
+          } as Response;
+        }
+        const paymentPayload = JSON.parse(Buffer.from(xPayment, 'base64').toString('utf-8')) as {
+          network: string;
+          payload?: { transactionCertificate?: unknown };
+        };
+        assert.equal(paymentPayload.network, 'fastset-mainnet');
+        assert.ok(paymentPayload.payload?.transactionCertificate, 'expected transactionCertificate in X-PAYMENT payload');
+        const body = { delivered: true };
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => body,
+          text: async () => JSON.stringify(body),
+        } as Response;
+      }
+
+      if (urlString === FAST_RPC_URL) {
+        const req = JSON.parse(String(init?.body)) as { method: string };
+        rpcMethods.push(req.method);
+        if (req.method === 'proxy_getAccountInfo') {
+          return rpcResponse({ balance: '0', next_nonce: 3 });
+        }
+        if (req.method === 'proxy_submitTransaction') {
+          return rpcResponse({
+            Success: { envelope: { transaction: { nonce: 3 } }, signatures: [] },
+          });
+        }
+        if (req.method === 'proxy_getTokenInfo') {
+          return rpcResponse({
+            requested_token_metadata: [[Array.from(setTokenId), {
+              token_name: 'SET',
+              decimals: 18,
+              total_supply: '0',
+              admin: [],
+              mints: [],
+              update_id: 0,
+            }]],
+          });
+        }
+      }
+
+      throw new Error(`Unexpected fetch URL: ${urlString}`);
+    }) as FetchFn;
+
+    const result = await money.x402Pay({ url: API_URL });
+
+    assert.equal(result.success, true);
+    assert.equal(result.statusCode, 200);
+    assert.equal(result.payment?.network, 'fastset-mainnet');
+    assert.equal(result.payment?.amount, '1');
+    assert.equal(result.payment?.amountRaw, '1000000000000000000');
+    assert.equal(result.payment?.decimals, 18);
+    assert.equal(result.payment?.token, 'SET');
+    assert.equal(apiCalls, 2);
+    assert.ok(rpcMethods.includes('proxy_getAccountInfo'));
+    assert.ok(rpcMethods.includes('proxy_submitTransaction'));
+  });
+
+  it('throws INVALID_PARAMS when 402 response omits accepts[].asset', async () => {
+    await money.setup({ chain: 'fast' });
+    let rpcCalled = false;
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlString = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlString === API_URL) {
+        const body = {
+          x402Version: 1,
+          accepts: [{
+            scheme: 'exact',
+            network: 'fastset-devnet',
+            maxAmountRequired: '1000',
+            payTo: RECIPIENT,
+          }],
+        };
+        return {
+          ok: false,
+          status: 402,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => body,
+          text: async () => JSON.stringify(body),
+        } as Response;
+      }
+
+      if (typeof init?.body === 'string' && init.body.includes('proxy_')) {
+        rpcCalled = true;
+      }
+      return rpcResponse(null);
+    }) as FetchFn;
+
+    await assert.rejects(
+      () => money.x402Pay({ url: API_URL }),
+      (err: unknown) => {
+        assert.ok(err instanceof MoneyError);
+        assert.equal(err.code, 'INVALID_PARAMS');
+        assert.ok(err.message.includes('Missing asset'));
+        return true;
+      },
+    );
+    assert.equal(rpcCalled, false);
+  });
+
+  it('returns raw amount when token metadata is unavailable', async () => {
+    await money.setup({ chain: 'fast' });
+    const tokenId = new Uint8Array(32);
+    tokenId.fill(0x42);
+    const tokenAsset = toAssetBase64(tokenId);
+    const largeRawAmount = '1234567890123456789012345678901234567890';
+    let apiCalls = 0;
+
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const urlString = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+
+      if (urlString === API_URL) {
+        apiCalls += 1;
+        if (!getHeader(init, 'X-PAYMENT')) {
+          const body = {
+            x402Version: 1,
+            accepts: [{
+              scheme: 'exact',
+              network: 'fastset-devnet',
+              maxAmountRequired: largeRawAmount,
+              payTo: RECIPIENT,
+              asset: tokenAsset,
+            }],
+          };
+          return {
+            ok: false,
+            status: 402,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: async () => body,
+            text: async () => JSON.stringify(body),
+          } as Response;
+        }
+        const body = { delivered: true };
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => body,
+          text: async () => JSON.stringify(body),
+        } as Response;
+      }
+
+      if (urlString === FAST_RPC_URL) {
+        const req = JSON.parse(String(init?.body)) as { method: string };
+        if (req.method === 'proxy_getAccountInfo') {
+          return rpcResponse({ balance: '0', next_nonce: 0 });
+        }
+        if (req.method === 'proxy_submitTransaction') {
+          return rpcResponse({
+            Success: { envelope: { transaction: { nonce: 0 } }, signatures: [] },
+          });
+        }
+        if (req.method === 'proxy_getTokenInfo') {
+          return rpcResponse({
+            requested_token_metadata: [[Array.from(tokenId), null]],
+          });
+        }
+      }
+
+      throw new Error(`Unexpected fetch URL: ${urlString}`);
+    }) as FetchFn;
+
+    const result = await money.x402Pay({ url: API_URL });
+
+    assert.equal(result.success, true);
+    assert.equal(apiCalls, 2);
+    assert.equal(result.payment?.amountRaw, largeRawAmount);
+    assert.equal(result.payment?.amount, largeRawAmount);
+    assert.equal(result.payment?.decimals, null);
+    assert.equal(result.payment?.token, 'TOKEN');
+    assert.ok(result.note.includes('raw units'));
+    assert.ok(!result.note.includes('USDC'));
+  });
+});


### PR DESCRIPTION
Summary\n- restore x402Pay to the SDK public surface (implementation, schemas, types, and tests)\n- fix refreshPaywallIntentStatus ordering to scan transfers before applying expiry\n\nWhy\n- x402Pay was previously available on main; its removal caused an SDK surface regression\n- expiring pending intents before scanning chain transfers can drop valid payments mined before expiry but observed later\n\nValidation\n- npx tsc --noEmit\n- npm run build:sdk && node --test --test-force-exit dist/tests/x402pay.test.js\n- full npm run test still has pre-existing failures in key-management tests (same baseline failure count)