### PR TITLE
Harden paywall Postgres init, locking, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ The paywall server API under `app/api/paywall/*` supports two state backends:
 - `PAYWALL_STORE_DRIVER=postgres`: durable production storage.
   - Requires `PAYWALL_DATABASE_URL` (or `DATABASE_URL`).
   - Optional: `PAYWALL_POSTGRES_STORE_KEY` (default `default`), `PAYWALL_DATABASE_SSL=require`.
+  - Runtime DDL: `PAYWALL_ALLOW_RUNTIME_DDL=true|false` (default: enabled outside production, disabled in `NODE_ENV=production`).
   - Dev-only insecure TLS override: `PAYWALL_DATABASE_SSL_INSECURE_SKIP_VERIFY=true` (not for production).
 
 ## Architecture

--- a/SKILL.md
+++ b/SKILL.md
@@ -247,6 +247,7 @@ Operational notes:
 - Optional postgres settings:
   - `PAYWALL_POSTGRES_STORE_KEY` to namespace a store row (default `default`).
   - `PAYWALL_DATABASE_SSL=require` for managed Postgres TLS.
+  - `PAYWALL_ALLOW_RUNTIME_DDL=true|false` to control runtime table creation (defaults to enabled in non-production and disabled in `NODE_ENV=production`).
   - `PAYWALL_DATABASE_SSL_INSECURE_SKIP_VERIFY=true` only for local/dev cert bypass.
 - Unlock token TTL defaults to 10 minutes.
 - Unlock token is one-time use; first successful data fetch consumes it.

--- a/app/lib/paywall/store.ts
+++ b/app/lib/paywall/store.ts
@@ -13,7 +13,6 @@ type StoreDriver = 'file' | 'postgres';
 
 const POSTGRES_TABLE = 'money_paywall_store';
 const POSTGRES_STORE_KEY = process.env.PAYWALL_POSTGRES_STORE_KEY?.trim() || 'default';
-const POSTGRES_LOCK_ID = '812947563281447303';
 const STORE_DRIVER = resolveStoreDriver();
 
 function resolveStoreDriver(): StoreDriver {
@@ -123,11 +122,37 @@ function resolvePostgresUrl(): string {
   return url;
 }
 
+function parseOptionalEnvBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return undefined;
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
+}
+
 function shouldAllowInsecurePostgresTls(): boolean {
-  const value = process.env.PAYWALL_DATABASE_SSL_INSECURE_SKIP_VERIFY
-    ?.trim()
-    .toLowerCase();
-  return value === '1' || value === 'true' || value === 'yes';
+  return parseOptionalEnvBoolean(process.env.PAYWALL_DATABASE_SSL_INSECURE_SKIP_VERIFY) === true;
+}
+
+function shouldAllowRuntimePostgresDdl(): boolean {
+  const explicit = parseOptionalEnvBoolean(process.env.PAYWALL_ALLOW_RUNTIME_DDL);
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  return process.env.NODE_ENV?.trim().toLowerCase() !== 'production';
+}
+
+async function ensurePostgresTableExists(pool: Pool): Promise<void> {
+  const result = await pool.query<{ exists: boolean }>(
+    'SELECT to_regclass($1) IS NOT NULL AS exists;',
+    [POSTGRES_TABLE],
+  );
+  if (result.rows[0]?.exists) {
+    return;
+  }
+  throw new Error(
+    `Paywall Postgres table "${POSTGRES_TABLE}" does not exist and runtime DDL is disabled. ` +
+      'Run database migrations to create this table or set PAYWALL_ALLOW_RUNTIME_DDL=true during initialization.',
+  );
 }
 
 function resolvePostgresSslConfig(): PoolConfig['ssl'] {
@@ -155,13 +180,17 @@ async function ensurePostgresStoreReady(): Promise<void> {
   if (!g.__moneyPaywallPgInitPromise) {
     g.__moneyPaywallPgInitPromise = (async () => {
       const pool = getPostgresPool();
-      await pool.query(`
-        CREATE TABLE IF NOT EXISTS ${POSTGRES_TABLE} (
-          store_key text PRIMARY KEY,
-          store_data jsonb NOT NULL,
-          updated_at timestamptz NOT NULL DEFAULT now()
-        );
-      `);
+      if (shouldAllowRuntimePostgresDdl()) {
+        await pool.query(`
+          CREATE TABLE IF NOT EXISTS ${POSTGRES_TABLE} (
+            store_key text PRIMARY KEY,
+            store_data jsonb NOT NULL,
+            updated_at timestamptz NOT NULL DEFAULT now()
+          );
+        `);
+      } else {
+        await ensurePostgresTableExists(pool);
+      }
       await pool.query(
         `
           INSERT INTO ${POSTGRES_TABLE} (store_key, store_data)
@@ -240,7 +269,14 @@ async function mutatePostgresStore<T>(
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-    await client.query('SELECT pg_advisory_xact_lock($1::bigint);', [POSTGRES_LOCK_ID]);
+    await client.query(
+      `
+        INSERT INTO ${POSTGRES_TABLE} (store_key, store_data)
+        VALUES ($1, $2::jsonb)
+        ON CONFLICT (store_key) DO NOTHING;
+      `,
+      [POSTGRES_STORE_KEY, JSON.stringify(defaultStore())],
+    );
     const readResult = await client.query<{ store_data: unknown }>(
       `
         SELECT store_data

--- a/sdk/tests/paywall-store-postgres.test.ts
+++ b/sdk/tests/paywall-store-postgres.test.ts
@@ -1,0 +1,247 @@
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+type StoreModule = {
+  readPaywallStore: () => Promise<Record<string, unknown>>;
+  mutatePaywallStore: <T>(
+    mutator: (store: Record<string, any>) => Promise<T> | T,
+  ) => Promise<T>;
+};
+
+type EnvKey =
+  | 'PAYWALL_STORE_DRIVER'
+  | 'PAYWALL_ALLOW_RUNTIME_DDL'
+  | 'PAYWALL_DATABASE_URL'
+  | 'DATABASE_URL'
+  | 'PAYWALL_POSTGRES_STORE_KEY'
+  | 'NODE_ENV';
+
+const ENV_KEYS: EnvKey[] = [
+  'PAYWALL_STORE_DRIVER',
+  'PAYWALL_ALLOW_RUNTIME_DDL',
+  'PAYWALL_DATABASE_URL',
+  'DATABASE_URL',
+  'PAYWALL_POSTGRES_STORE_KEY',
+  'NODE_ENV',
+];
+
+const ORIGINAL_ENV = new Map<EnvKey, string | undefined>(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const storeSourcePath = path.join(repoRoot, 'app/lib/paywall/store.ts');
+
+let tmpDir = '';
+let compiledModulePath = '';
+
+function defaultStoreData(): Record<string, unknown> {
+  return {
+    version: 1,
+    products: {},
+    products_by_slug: {},
+    assets: {},
+    receiver_accounts: {},
+    intents: {},
+    payment_events: {},
+    unlock_grants: {},
+    seen_transfers: {},
+    seen_webhook_events: {},
+  };
+}
+
+function resetGlobals(): void {
+  delete (globalThis as any).__moneyPaywallPgPool;
+  delete (globalThis as any).__moneyPaywallPgInitPromise;
+  delete (globalThis as any).__moneyPaywallStoreWriteQueue;
+}
+
+function restoreEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = ORIGINAL_ENV.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function loadStoreModule(): StoreModule {
+  delete require.cache[compiledModulePath];
+  return require(compiledModulePath) as StoreModule;
+}
+
+before(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'money-paywall-store-test-'));
+  compiledModulePath = path.join(tmpDir, 'paywall-store.cjs');
+  await build({
+    entryPoints: [storeSourcePath],
+    outfile: compiledModulePath,
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    target: 'node18',
+    logLevel: 'silent',
+  });
+});
+
+after(async () => {
+  restoreEnv();
+  resetGlobals();
+  if (tmpDir) {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+beforeEach(() => {
+  restoreEnv();
+  resetGlobals();
+});
+
+afterEach(() => {
+  restoreEnv();
+  resetGlobals();
+});
+
+describe('paywall postgres store runtime safety', () => {
+  it('fails with a targeted error when runtime DDL is disabled and table is missing', async () => {
+    process.env.PAYWALL_STORE_DRIVER = 'postgres';
+    process.env.PAYWALL_ALLOW_RUNTIME_DDL = 'false';
+    process.env.NODE_ENV = 'production';
+
+    const poolQueries: string[] = [];
+    (globalThis as any).__moneyPaywallPgPool = {
+      query: async (sql: string) => {
+        poolQueries.push(sql);
+        if (sql.includes('to_regclass')) {
+          return { rowCount: 1, rows: [{ exists: false }] };
+        }
+        throw new Error(`Unexpected pool query: ${sql}`);
+      },
+      connect: async () => {
+        throw new Error('connect should not be called for init failure');
+      },
+    };
+
+    const storeModule = loadStoreModule();
+    await assert.rejects(
+      () => storeModule.readPaywallStore(),
+      /runtime DDL is disabled/i,
+    );
+    assert.equal(poolQueries.some((sql) => sql.includes('to_regclass')), true);
+    assert.equal(poolQueries.some((sql) => sql.includes('CREATE TABLE')), false);
+  });
+
+  it('runs CREATE TABLE only when runtime DDL is enabled', async () => {
+    process.env.PAYWALL_STORE_DRIVER = 'postgres';
+    process.env.PAYWALL_ALLOW_RUNTIME_DDL = 'true';
+
+    const poolQueries: string[] = [];
+    (globalThis as any).__moneyPaywallPgPool = {
+      query: async (sql: string) => {
+        poolQueries.push(sql);
+        if (sql.includes('CREATE TABLE IF NOT EXISTS')) {
+          return { rowCount: 0, rows: [] };
+        }
+        if (sql.includes('ON CONFLICT (store_key) DO NOTHING')) {
+          return { rowCount: 1, rows: [] };
+        }
+        if (sql.includes('SELECT store_data')) {
+          return { rowCount: 1, rows: [{ store_data: defaultStoreData() }] };
+        }
+        throw new Error(`Unexpected pool query: ${sql}`);
+      },
+      connect: async () => {
+        throw new Error('connect should not be called in read test');
+      },
+    };
+
+    const storeModule = loadStoreModule();
+    const store = await storeModule.readPaywallStore();
+    assert.equal(store.version, 1);
+    assert.equal(poolQueries.some((sql) => sql.includes('CREATE TABLE IF NOT EXISTS')), true);
+    assert.equal(poolQueries.some((sql) => sql.includes('to_regclass')), false);
+  });
+
+  it('uses row-level locking without advisory transaction locks during mutation', async () => {
+    process.env.PAYWALL_STORE_DRIVER = 'postgres';
+    process.env.PAYWALL_ALLOW_RUNTIME_DDL = 'true';
+
+    const poolQueries: string[] = [];
+    const clientQueries: string[] = [];
+    let released = false;
+
+    const fakeClient = {
+      query: async (sql: string) => {
+        clientQueries.push(sql);
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+          return { rowCount: 0, rows: [] };
+        }
+        if (
+          sql.includes('INSERT INTO money_paywall_store')
+          && sql.includes('ON CONFLICT (store_key) DO NOTHING')
+        ) {
+          return { rowCount: 1, rows: [] };
+        }
+        if (sql.includes('SELECT store_data') && sql.includes('FOR UPDATE')) {
+          return { rowCount: 1, rows: [{ store_data: defaultStoreData() }] };
+        }
+        if (
+          sql.includes('INSERT INTO money_paywall_store')
+          && sql.includes('updated_at')
+          && sql.includes('ON CONFLICT (store_key) DO UPDATE')
+        ) {
+          return { rowCount: 1, rows: [] };
+        }
+        throw new Error(`Unexpected client query: ${sql}`);
+      },
+      release: () => {
+        released = true;
+      },
+    };
+
+    (globalThis as any).__moneyPaywallPgPool = {
+      query: async (sql: string) => {
+        poolQueries.push(sql);
+        if (sql.includes('CREATE TABLE IF NOT EXISTS')) {
+          return { rowCount: 0, rows: [] };
+        }
+        if (sql.includes('ON CONFLICT (store_key) DO NOTHING')) {
+          return { rowCount: 1, rows: [] };
+        }
+        throw new Error(`Unexpected pool query: ${sql}`);
+      },
+      connect: async () => fakeClient,
+    };
+
+    const storeModule = loadStoreModule();
+    const result = await storeModule.mutatePaywallStore((store) => {
+      store.seen_webhook_events.evt_1 = true;
+      return 'ok';
+    });
+
+    assert.equal(result, 'ok');
+    assert.equal(released, true);
+    assert.equal(clientQueries.some((sql) => sql.includes('pg_advisory_xact_lock')), false);
+    assert.equal(clientQueries.some((sql) => sql.includes('FOR UPDATE')), true);
+
+    const ensureRowIndex = clientQueries.findIndex(
+      (sql) => sql.includes('ON CONFLICT (store_key) DO NOTHING'),
+    );
+    const lockRowIndex = clientQueries.findIndex((sql) => sql.includes('FOR UPDATE'));
+    assert.equal(ensureRowIndex >= 0, true);
+    assert.equal(lockRowIndex >= 0, true);
+    assert.equal(ensureRowIndex < lockRowIndex, true);
+
+    assert.equal(poolQueries.some((sql) => sql.includes('CREATE TABLE IF NOT EXISTS')), true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- gate runtime Postgres DDL behind `PAYWALL_ALLOW_RUNTIME_DDL` (defaults: enabled outside production, disabled in `NODE_ENV=production`)
- when runtime DDL is disabled, validate table existence with a targeted migration error
- remove global advisory tx lock and rely on row-level locking (`SELECT ... FOR UPDATE`)
- ensure store row existence inside mutate transaction before row lock
- document the new runtime DDL env flag in `README.md` and `SKILL.md`
- add automated tests for DDL-guard behavior and lock semantics

## Validation
- `npm run build`
- `npm run build:sdk && node --test --test-force-exit dist/tests/paywall-store-postgres.test.js`
- full `npm test` is currently blocked in sandbox by existing key tests writing under `/Users/chris` (EPERM), unrelated to this change
