### PR TITLE
Improve landing text contrast on light mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -529,7 +529,7 @@ code { font-family: var(--font-mono), 'SF Mono', 'Consolas', monospace; }
   font-size: 0.75rem;
   font-weight: 500;
   letter-spacing: 0.3px;
-  color: rgba(242, 245, 250, 0.72);
+  color: rgba(34, 38, 45, 0.84);
   margin-bottom: 1rem;
 }
 
@@ -558,6 +558,14 @@ code { font-family: var(--font-mono), 'SF Mono', 'Consolas', monospace; }
 }
 
 .landing-shell .install-hint {
+  color: rgba(45, 54, 66, 0.8);
+}
+
+:root[data-theme='dark'] .landing-title {
+  color: rgba(242, 245, 250, 0.72);
+}
+
+:root[data-theme='dark'] .landing-shell .install-hint {
   color: rgba(214, 223, 235, 0.72);
 }
 


### PR DESCRIPTION
## Summary
- darken landing subtitle text on light mode background
- darken `one command, that's it` helper text for readability
- keep existing lighter colors under dark theme overrides