### PR TITLE
Disable waitlist captcha by default via feature flag

### DIFF
--- a/app/api/waitlist/route.ts
+++ b/app/api/waitlist/route.ts
@@ -6,9 +6,24 @@ type TurnstileResponse = {
 };
 
 const DEFAULT_WAITLIST_ENDPOINT = 'https://sheetdb.io/api/v1/k795qny6qgb93';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]']);
+const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
 
 function isValidEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function isLocalRequest(hostname: string): boolean {
+  return LOCAL_HOSTNAMES.has(hostname.toLowerCase());
+}
+
+function isCaptchaEnabled(): boolean {
+  const flag = (
+    process.env.WAITLIST_CAPTCHA_ENABLED ||
+    process.env.NEXT_PUBLIC_WAITLIST_CAPTCHA_ENABLED ||
+    ''
+  ).trim().toLowerCase();
+  return ENABLED_VALUES.has(flag);
 }
 
 export async function POST(request: NextRequest) {
@@ -16,8 +31,10 @@ export async function POST(request: NextRequest) {
     const body = (await request.json().catch(() => ({}))) as { email?: string; token?: string };
     const email = body.email?.trim() ?? '';
     const token = body.token?.trim() ?? '';
+    const localBypass = process.env.NODE_ENV === 'development' || isLocalRequest(request.nextUrl.hostname);
+    const captchaRequired = isCaptchaEnabled() && !localBypass;
 
-    if (!email || !token) {
+    if (!email || (!token && captchaRequired)) {
       return NextResponse.json(
         { message: 'Email and captcha token are required.' },
         { status: 400 },
@@ -28,7 +45,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: 'Please provide a valid email address.' }, { status: 400 });
     }
 
-    if (process.env.NODE_ENV !== 'development') {
+    if (captchaRequired) {
       const secret = process.env.TURNSTILE_SECRET_KEY;
       if (!secret) {
         return NextResponse.json({ message: 'Captcha is not configured on the server.' }, { status: 500 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,11 @@ import { DemoSidebarShell } from './components/demo-sidebar-shell';
 import { ThemeToggle } from './components/theme-toggle';
 import './globals.css';
 
+const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const WAITLIST_CAPTCHA_ENABLED = ENABLED_VALUES.has(
+  (process.env.NEXT_PUBLIC_WAITLIST_CAPTCHA_ENABLED || '').trim().toLowerCase(),
+);
+
 const generalSans = localFont({
   src: [
     { path: '../public/fonts/GeneralSans-Light.otf', weight: '300' },
@@ -60,10 +65,12 @@ export default function RootLayout({
         <Script id="theme-init" strategy="beforeInteractive">
           {THEME_INIT_SCRIPT}
         </Script>
-        <Script
-          src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
-          strategy="afterInteractive"
-        />
+        {WAITLIST_CAPTCHA_ENABLED ? (
+          <Script
+            src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+            strategy="afterInteractive"
+          />
+        ) : null}
         <nav className="nav">
           <div className="nav-inner">
             <a href="/" className="nav-wordmark">

--- a/app/waitlist/page.tsx
+++ b/app/waitlist/page.tsx
@@ -15,20 +15,24 @@ declare global {
 
 type WaitlistStatus = 'idle' | 'loading' | 'success' | 'error';
 
-const IS_DEV = process.env.NODE_ENV === 'development';
+const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const CAPTCHA_FLAG = (process.env.NEXT_PUBLIC_WAITLIST_CAPTCHA_ENABLED || '').trim().toLowerCase();
+const WAITLIST_CAPTCHA_ENABLED = ENABLED_VALUES.has(CAPTCHA_FLAG);
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY?.trim() || '';
+const CAPTCHA_ENABLED = WAITLIST_CAPTCHA_ENABLED && TURNSTILE_SITE_KEY.length > 0;
 const CAPTCHA_TIMEOUT_MS = 10000;
 
 export default function WaitlistPage() {
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<WaitlistStatus>('idle');
-  const [message, setMessage] = useState('Dummy waitlist input for now.');
-  const [turnstileToken, setTurnstileToken] = useState<string | null>(IS_DEV ? 'dev-bypass' : null);
+  const [message, setMessage] = useState('');
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(CAPTCHA_ENABLED ? null : 'local-bypass');
   const [captchaLoadFailed, setCaptchaLoadFailed] = useState(false);
   const turnstileRef = useRef<HTMLDivElement | null>(null);
   const widgetIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (IS_DEV) return;
+    if (!CAPTCHA_ENABLED) return;
 
     let renderAttempted = false;
     let intervalId: ReturnType<typeof setInterval> | undefined;
@@ -48,7 +52,7 @@ export default function WaitlistPage() {
 
       try {
         widgetIdRef.current = window.turnstile.render(turnstileRef.current, {
-          sitekey: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
+          sitekey: TURNSTILE_SITE_KEY,
           callback: (token: string) => {
             setTurnstileToken(token);
             setCaptchaLoadFailed(false);
@@ -105,7 +109,7 @@ export default function WaitlistPage() {
       return;
     }
 
-    if (!turnstileToken) {
+    if (CAPTCHA_ENABLED && !turnstileToken) {
       setStatus('error');
       setMessage(
         captchaLoadFailed
@@ -165,10 +169,12 @@ export default function WaitlistPage() {
                 {status === 'loading' ? 'Submitting...' : 'Join the waitlist'}
               </button>
             </form>
-            <p className={`waitlist-note${status === 'error' ? ' is-error' : ''}${status === 'success' ? ' is-success' : ''}`}>
-              {message}
-            </p>
-            {!IS_DEV && status !== 'success' ? (
+            {message ? (
+              <p className={`waitlist-note${status === 'error' ? ' is-error' : ''}${status === 'success' ? ' is-success' : ''}`}>
+                {message}
+              </p>
+            ) : null}
+            {CAPTCHA_ENABLED && status !== 'success' ? (
               <div className="waitlist-captcha-wrap">
                 <div ref={turnstileRef} />
               </div>


### PR DESCRIPTION
## Summary
- add waitlist captcha feature flags on client and server
- disable captcha by default while keeping Turnstile integration code
- gate global Turnstile script injection behind the same flag
- keep waitlist submit working when captcha is disabled