### PR TITLE
Backup for nextjs-examples-from-old-mono-sdk

### DIFF
--- a/ARCHIVE_NEXTJS_EXAMPLES_OLD_MONO_SDK.md
+++ b/ARCHIVE_NEXTJS_EXAMPLES_OLD_MONO_SDK.md
@@ -1,0 +1,11 @@
+## Archive: Old Monolith Next.js Examples
+
+This branch preserves the pre-split Next.js example app that depended on the old monolithic `money` SDK surface.
+
+It exists as a backup reference while `main` is pruned down to the smaller app that matches the split SDK packages.
+
+Intended use:
+
+- review or recover the old example pages and routes
+- compare the old monolith-oriented app against the split-SDK app
+- keep a stable branch/PR reference during the migration


### PR DESCRIPTION
## Summary
- keep a backup PR for the old monolith-based Next.js example app
- preserve the pre-split pages and routes as a reference branch while main is pruned

## Future Plan
- keep this PR open as an archive reference, similar to PR #24
- move main toward the smaller Next.js app that only matches the split SDK surfaces

## Notes
- this branch intentionally only adds an archive note file
- the old app code remains preserved by the branch itself