### PR TITLE
Add Fast wallet x402 payment example

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,7 +26,7 @@ npx skills add fastxyz/fast-skill
 
 ## Example Requests
 
-- "Check my FAST testnet balance and send SET to another `fast1...` address"
+- "Check my FAST testnet balance and send FAST to another `fast1...` address"
 - "Bridge USDC from Arbitrum Sepolia into Fast"
 - "Use the FAST x402 packages to protect an Express API route"
 
@@ -38,7 +38,7 @@ npx skills add fastxyz/fast-skill
 
 ## Package Map
 
-- `@fastxyz/sdk`: Fast network wallet setup, balances, sends, signing, token lookup, low-level claim submission
+- `@fastxyz/sdk`: `FastProvider` read-only access plus `FastWallet` signing, sends, token lookup, and low-level claim submission
 - `@fastxyz/allset-sdk`: bridge flows between Fast and supported EVM routes
 - `@fastxyz/x402-client`: pay 402-protected APIs
 - `@fastxyz/x402-server`: return 402 requirements and protect routes

--- a/flows/fast-to-fast-payment.md
+++ b/flows/fast-to-fast-payment.md
@@ -5,24 +5,24 @@ Use `@fastxyz/sdk` for direct Fast transfers.
 ## Steps
 
 1. Install `@fastxyz/sdk`
-2. Create the client on `testnet` unless the user explicitly asked for mainnet
-3. Call `setup()` once
+2. Create a `FastProvider` on `testnet` unless the user explicitly asked for mainnet
+3. Create a `FastWallet` from the keyfile you want to send from
 4. Check balance
 5. Call `send({ to, amount, token? })`
 
 ## Example
 
 ```ts
-import { fast } from '@fastxyz/sdk';
+import { FastProvider, FastWallet } from '@fastxyz/sdk';
 
-const f = fast({ network: 'testnet' });
+const provider = new FastProvider({ network: 'testnet' });
+const wallet = await FastWallet.fromKeyfile('~/.fast/keys/default.json', provider);
 
-await f.setup();
-
-const before = await f.balance();
-const sent = await f.send({
+const before = await wallet.balance();
+const sent = await wallet.send({
   to: 'fast1recipient...',
   amount: '1.0',
+  token: 'FAST',
 });
 
 console.log(before, sent);
@@ -32,4 +32,5 @@ console.log(before, sent);
 
 - recipient must be `fast1...`
 - amount is a human-readable string
+- use `FastProvider` for read-only checks and `FastWallet` for the signed send
 - do not proceed if the user has not confirmed the recipient

--- a/flows/x402-pay-an-api.md
+++ b/flows/x402-pay-an-api.md
@@ -16,13 +16,16 @@ import { x402Pay } from '@fastxyz/x402-client';
 
 const fastClient = fast({ network: 'testnet' });
 
-await fastClient.setup();
+const { address } = await fastClient.setup();
 
-const { publicKey, address } = await fastClient.exportKeys();
-const fastConfigDir = process.env.FAST_CONFIG_DIR
-  ? process.env.FAST_CONFIG_DIR.startsWith('~')
-    ? path.join(os.homedir(), process.env.FAST_CONFIG_DIR.slice(1))
-    : process.env.FAST_CONFIG_DIR
+const { publicKey } = await fastClient.exportKeys();
+const envFastConfigDir = process.env.FAST_CONFIG_DIR;
+const fastConfigDir = envFastConfigDir
+  ? envFastConfigDir === '~'
+    ? os.homedir()
+    : envFastConfigDir.startsWith('~/')
+      ? path.join(os.homedir(), envFastConfigDir.slice(2))
+      : envFastConfigDir
   : path.join(os.homedir(), '.fast');
 const keyfilePath = path.join(fastConfigDir, 'keys', 'fast.json');
 const { privateKey } = JSON.parse(

--- a/flows/x402-pay-an-api.md
+++ b/flows/x402-pay-an-api.md
@@ -2,6 +2,47 @@
 
 Use `@fastxyz/x402-client` when the user is the payer.
 
+## Fast Example
+
+`@fastxyz/sdk` creates or loads the local Fast wallet during `setup()`. The current SDK stores the keypair at `~/.fast/keys/fast.json` by default, or at `$FAST_CONFIG_DIR/keys/fast.json` if `FAST_CONFIG_DIR` is set. `exportKeys()` returns `publicKey` and `address`, so read the keyfile to get `privateKey` before calling `x402Pay(...)`.
+
+```ts
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { fast } from '@fastxyz/sdk';
+import { x402Pay } from '@fastxyz/x402-client';
+
+const fastClient = fast({ network: 'testnet' });
+
+await fastClient.setup();
+
+const { publicKey, address } = await fastClient.exportKeys();
+const fastConfigDir = process.env.FAST_CONFIG_DIR
+  ? process.env.FAST_CONFIG_DIR.startsWith('~')
+    ? path.join(os.homedir(), process.env.FAST_CONFIG_DIR.slice(1))
+    : process.env.FAST_CONFIG_DIR
+  : path.join(os.homedir(), '.fast');
+const keyfilePath = path.join(fastConfigDir, 'keys', 'fast.json');
+const { privateKey } = JSON.parse(
+  await fs.readFile(keyfilePath, 'utf8'),
+) as {
+  privateKey: string;
+};
+
+const result = await x402Pay({
+  url: 'https://api.example.com/premium',
+  wallet: {
+    type: 'fast',
+    privateKey,
+    publicKey,
+    address,
+  },
+  verbose: true,
+});
+```
+
 ## EVM Example
 
 ```ts

--- a/flows/x402-pay-an-api.md
+++ b/flows/x402-pay-an-api.md
@@ -4,34 +4,34 @@ Use `@fastxyz/x402-client` when the user is the payer.
 
 ## Fast Example
 
-`@fastxyz/sdk` creates or loads the local Fast wallet during `setup()`. The current SDK stores the keypair at `~/.fast/keys/fast.json` by default, or at `$FAST_CONFIG_DIR/keys/fast.json` if `FAST_CONFIG_DIR` is set. `exportKeys()` returns `publicKey` and `address`, so read the keyfile to get `privateKey` before calling `x402Pay(...)`.
+Use `FastProvider` for the connection and `FastWallet` for the Fast identity. `x402Pay(...)` still needs the raw private key, so read it from the same keyfile path you give to `FastWallet.fromKeyfile(...)`. The SDK default is `~/.fast/keys/default.json`, or `$FAST_CONFIG_DIR/keys/default.json` when `FAST_CONFIG_DIR` is set. Current keyfiles are JSON with `{ privateKey, address }`.
 
 ```ts
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { fast } from '@fastxyz/sdk';
+import { FastProvider, FastWallet } from '@fastxyz/sdk';
 import { x402Pay } from '@fastxyz/x402-client';
 
-const fastClient = fast({ network: 'testnet' });
+function getFastConfigDir(): string {
+  const override = process.env.FAST_CONFIG_DIR;
+  if (!override) return path.join(os.homedir(), '.fast');
+  if (override === '~') return os.homedir();
+  if (override.startsWith('~/')) return path.join(os.homedir(), override.slice(2));
+  return override;
+}
 
-const { address } = await fastClient.setup();
+const keyfilePath = path.join(getFastConfigDir(), 'keys', 'default.json');
+const provider = new FastProvider({ network: 'testnet' });
+const wallet = await FastWallet.fromKeyfile(keyfilePath, provider);
 
-const { publicKey } = await fastClient.exportKeys();
-const envFastConfigDir = process.env.FAST_CONFIG_DIR;
-const fastConfigDir = envFastConfigDir
-  ? envFastConfigDir === '~'
-    ? os.homedir()
-    : envFastConfigDir.startsWith('~/')
-      ? path.join(os.homedir(), envFastConfigDir.slice(2))
-      : envFastConfigDir
-  : path.join(os.homedir(), '.fast');
-const keyfilePath = path.join(fastConfigDir, 'keys', 'fast.json');
+const { publicKey, address } = await wallet.exportKeys();
 const { privateKey } = JSON.parse(
   await fs.readFile(keyfilePath, 'utf8'),
 ) as {
   privateKey: string;
+  address: string;
 };
 
 const result = await x402Pay({
@@ -83,4 +83,5 @@ const result = await x402Pay({
 ## Checks
 
 - if both Fast and EVM are accepted, the client prefers Fast
+- if you load a named key or custom keyfile, read the `privateKey` from that same path instead of assuming `default.json`
 - auto-bridge depends on explicit bridge helper configs, not a generic any-chain path

--- a/references/capabilities.md
+++ b/references/capabilities.md
@@ -6,7 +6,7 @@ Use this file to decide which FAST package owns a request and whether the reques
 
 | Package | Use it for | Do not use it for |
 |---|---|---|
-| `@fastxyz/sdk` | Fast wallet setup, balance checks, sends, message signing, token metadata, low-level claim submission | EVM execution, bridging, x402 paywall logic |
+| `@fastxyz/sdk` | FastProvider read-only queries, FastWallet sends and signing, token metadata, low-level claim submission | EVM execution, bridging, x402 paywall logic |
 | `@fastxyz/allset-sdk` | Fast <-> EVM bridge flows | Generic Fast wallet work or arbitrary EVM <-> EVM routing |
 | `@fastxyz/x402-client` | Paying 402-protected APIs | Protecting routes or running settlement infra |
 | `@fastxyz/x402-server` | Returning 402 requirements, route protection, payment verification hooks | Signing client payments or settling on-chain by itself |
@@ -17,9 +17,10 @@ Use this file to decide which FAST package owns a request and whether the reques
 ### Fast SDK
 
 - Package: `@fastxyz/sdk`
-- Networks: `testnet`, `mainnet`
+- Networks: built-in `testnet` and `mainnet`, plus custom names from `~/.fast/networks.json`
 - Default: `testnet`
-- Main surface: `fast({ network? })`
+- Main surface: `new FastProvider({ network?, rpcUrl?, explorerUrl? })` for reads, then `FastWallet.fromKeyfile(..., provider)` or `FastWallet.fromPrivateKey(..., provider)` for signing
+- Package split: none. `FastProvider` and `FastWallet` are both exported from the same `@fastxyz/sdk` package.
 - Safe assumption: use this for direct Fast work unless the user explicitly needs a bridge or x402 flow
 
 ### AllSet SDK

--- a/references/fast-sdk.md
+++ b/references/fast-sdk.md
@@ -11,45 +11,68 @@ npm install @fastxyz/sdk
 ## Public API
 
 ```ts
-import { fast, FastError } from '@fastxyz/sdk';
+import { FastProvider, FastWallet, FastError } from '@fastxyz/sdk';
 
-const f = fast({ network: 'testnet' });
+const provider = new FastProvider({ network: 'testnet' });
+const wallet = await FastWallet.fromKeyfile('~/.fast/keys/default.json', provider);
 ```
 
-- `fast({ network?, rpcUrl? })`: create a client
+- `FastProvider`: read-only RPC access for balances, token metadata, account info, and explorer links
+- `FastWallet`: signing and sending surface; always requires a `FastProvider`
 - `FastError`: typed operational errors with `code`, `message`, and optional `note`
 
 ## Standard Flow
 
 ```ts
-const f = fast({ network: 'testnet' });
+const provider = new FastProvider({ network: 'testnet' });
 
-const { address } = await f.setup();
-const balance = await f.balance();
-const sent = await f.send({ to: 'fast1...', amount: '1.0' });
+const balance = await provider.getBalance('fast1...');
+const tokenInfo = await provider.getTokenInfo('fastUSDC');
 ```
 
-Call `setup()` before everything else. It creates or loads the local wallet and returns the `fast1...` address.
+```ts
+const provider = new FastProvider({ network: 'testnet' });
+const wallet = await FastWallet.fromKeyfile('~/.fast/keys/default.json', provider);
+
+const balance = await wallet.balance();
+const sent = await wallet.send({ to: 'fast1...', amount: '1.0' });
+const signed = await wallet.sign({ message: 'hello fast' });
+```
+
+Read-only work stays on `FastProvider`. Anything that signs or submits transactions uses `FastWallet`.
 
 ## Methods That Matter
 
-- `setup()`: create or load the wallet
-- `balance({ token? })`: get native `SET` or a token by held symbol or token id
-- `send({ to, amount, token? })`: send native `SET` or a custom token
-- `sign({ message })`: sign with the local Ed25519 key
-- `verify({ message, signature, address })`: verify a signature
-- `tokens()`: list held tokens and balances
-- `tokenInfo({ token })`: fetch metadata for a held symbol or token id
-- `submit({ recipient, claim })`: low-level custom claim submission
-- `exportKeys()`: return public key and address only
-- `address`: current wallet address after setup
+- `FastProvider.getBalance(address, token?)`: get native `FAST` or a token by symbol or token id
+- `FastProvider.getTokens(address)`: list held token balances for any Fast address
+- `FastProvider.getTokenInfo(token)`: fetch token metadata by symbol or token id
+- `FastProvider.getAccountInfo(address)`: fetch raw account data from RPC
+- `FastProvider.getExplorerUrl(txHash?)`: build an explorer URL when the network config has one
+- `FastWallet.fromKeyfile(pathOrOpts, provider)`: load or create a wallet from disk
+- `FastWallet.fromPrivateKey(privateKey, provider)`: load an in-memory wallet from a raw private key
+- `FastWallet.generate(provider)`: create a new in-memory wallet
+- `wallet.balance(token?)`: get this wallet's balance
+- `wallet.send({ to, amount, token? })`: send native `FAST` or a custom token
+- `wallet.sign({ message })`: sign with the local Ed25519 key
+- `wallet.verify({ message, signature, address })`: verify a signature
+- `wallet.tokens()`: list held tokens and balances
+- `wallet.submit({ recipient, claim })`: low-level custom claim submission
+- `wallet.exportKeys()`: return public key and address only
+- `wallet.saveToKeyfile(path)`: persist an in-memory wallet created with `generate()` or `fromPrivateKey()`
+- `wallet.address`: current wallet address
 
 ## Important Data Rules
 
 - Default network is `testnet`. Only use `mainnet` if the user explicitly asks.
 - Transfer amounts are human-readable strings, for example `'1.5'`.
 - Fast addresses must be bech32m with `fast` prefix.
-- The native token is `SET`.
+- The native token is `FAST`.
+- `@fastxyz/sdk` is still one package. The API split is `FastProvider` plus `FastWallet`, not separate npm packages.
+- The default keyfile location is `~/.fast/keys/default.json`, or `$FAST_CONFIG_DIR/keys/default.json` if `FAST_CONFIG_DIR` is set.
+- Named keys resolve to `~/.fast/keys/<name>.json` or `$FAST_CONFIG_DIR/keys/<name>.json`.
+- `FastWallet.fromKeyfile(...)` creates a missing keyfile by default. Pass `createIfMissing: false` when the file must already exist.
+- Current keyfiles are written as `{ privateKey, address }`. The loader still accepts legacy `{ publicKey, privateKey }`.
+- Custom networks and token aliases come from `~/.fast/networks.json` and `~/.fast/tokens.json`, or the same files under `$FAST_CONFIG_DIR`.
 
 ## Safety Rules
 
@@ -61,12 +84,13 @@ Call `setup()` before everything else. It creates or loads the local wallet and 
 
 The package throws `FastError`. Common codes:
 
-- `CHAIN_NOT_CONFIGURED`: call `setup()` first
+- `KEYFILE_NOT_FOUND`: the requested keyfile is missing and `createIfMissing` was disabled
 - `INSUFFICIENT_BALANCE`: fund the wallet and retry
 - `INVALID_ADDRESS`: fix the `fast1...` address
-- `TOKEN_NOT_FOUND`: use a held symbol or a valid token id
+- `TOKEN_NOT_FOUND`: use a configured symbol such as `FAST` or `fastUSDC`, or pass a valid hex token id
 - `TX_FAILED`: wait, inspect, retry once if appropriate
 - `INVALID_PARAMS`: fix the input shape
+- `UNSUPPORTED_OPERATION`: for example, trying to `saveToKeyfile()` on a wallet already loaded from disk
 
 ## Use This Instead Of Other FAST Packages When
 


### PR DESCRIPTION
## Summary
- add a Fast wallet payment example to the x402 pay flow doc
- show how to read the Fast keyfile after setup() and pass privateKey/publicKey/address to x402Pay
- document the current keyfile location as ~/.fast/keys/fast.json or $FAST_CONFIG_DIR/keys/fast.json

## Testing
- not run (docs only)