### PR TITLE
Sync fast-skill docs to current FAST SDK surfaces

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -25,6 +25,15 @@ Single entrypoint for the FAST SDK ecosystem.
 npx skills add fastxyz/fast-skill
 ```
 
+## Bundled Docs
+
+This skill ships its own Markdown docs inside the installed skill directory.
+
+- Treat `references/*.md` and `flows/*.md` as local bundled files, not web URLs.
+- Resolve them relative to this `SKILL.md`.
+- Open the file path directly if your runtime does not expose clickable Markdown links.
+- Do not assume GitHub access is required to read these docs.
+
 ## Example Requests
 
 - "Check my FAST testnet balance and send SET to another `fast1...` address"
@@ -50,25 +59,25 @@ If an umbrella x402 package is introduced later, treat it as a wrapper. The curr
 
 ## Start Here
 
-Read [references/capabilities.md](./references/capabilities.md) first when the request involves multiple packages or unclear support.
+Read `references/capabilities.md` first when the request involves multiple packages or unclear support.
 
 Then route by task:
 
-- Fast wallet, balance, send, token info, signatures: [references/fast-sdk.md](./references/fast-sdk.md)
-- Bridge between Fast and EVM: [references/allset-sdk.md](./references/allset-sdk.md)
-- Pay for a protected API: [references/x402-client.md](./references/x402-client.md)
-- Add payments to an API: [references/x402-server.md](./references/x402-server.md)
-- Run verification or settlement infrastructure: [references/x402-facilitator.md](./references/x402-facilitator.md)
+- Fast wallet, balance, send, token info, signatures: `references/fast-sdk.md`
+- Bridge between Fast and EVM: `references/allset-sdk.md`
+- Pay for a protected API: `references/x402-client.md`
+- Add payments to an API: `references/x402-server.md`
+- Run verification or settlement infrastructure: `references/x402-facilitator.md`
 
 Load a flow playbook when the user asks for an end-to-end scenario:
 
-- Fast to Fast transfer: [flows/fast-to-fast-payment.md](./flows/fast-to-fast-payment.md)
-- EVM to Fast deposit: [flows/evm-to-fast-deposit.md](./flows/evm-to-fast-deposit.md)
-- Fast to EVM withdraw: [flows/fast-to-evm-withdraw.md](./flows/fast-to-evm-withdraw.md)
-- Top up Fast wallet via hosted ramp: [flows/top-up-fast-wallet-via-ramp.md](./flows/top-up-fast-wallet-via-ramp.md)
-- Chain to chain via Fast: [flows/chain-to-chain-via-fast.md](./flows/chain-to-chain-via-fast.md)
-- Pay an x402 API: [flows/x402-pay-an-api.md](./flows/x402-pay-an-api.md)
-- Protect an x402 API: [flows/x402-protect-an-api.md](./flows/x402-protect-an-api.md)
+- Fast to Fast transfer: `flows/fast-to-fast-payment.md`
+- EVM to Fast deposit: `flows/evm-to-fast-deposit.md`
+- Fast to EVM withdraw: `flows/fast-to-evm-withdraw.md`
+- Top up Fast wallet via hosted ramp: `flows/top-up-fast-wallet-via-ramp.md`
+- Chain to chain via Fast: `flows/chain-to-chain-via-fast.md`
+- Pay an x402 API: `flows/x402-pay-an-api.md`
+- Protect an x402 API: `flows/x402-protect-an-api.md`
 
 ## Routing Rules
 
@@ -82,7 +91,7 @@ Load a flow playbook when the user asks for an end-to-end scenario:
 
 - `@fastxyz/sdk` ships `testnet` and `mainnet` defaults and can also load custom named networks from config.
 - `@fastxyz/allset-sdk` ships bundled testnet routes only: `ethereum` (chain ID `11155111`), `arbitrum` (`421614`), and `base` (`8453`). The bundled mainnet `chains` map is empty.
-- x402 client, server, and facilitator do not expose the same network set. Check [references/capabilities.md](./references/capabilities.md) before promising an end-to-end paid API flow.
+- x402 client, server, and facilitator do not expose the same network set. Check `references/capabilities.md` before promising an end-to-end paid API flow.
 
 ### 3. Treat support limits as code-level constraints
 
@@ -102,7 +111,7 @@ Load a flow playbook when the user asks for an end-to-end scenario:
 ## Common Issues
 
 - If the request only says `x402` or `402`, confirm it is specifically about the FAST `@fastxyz/*` packages before routing here.
-- If the user asks for unsupported routes or token mappings, stop and cite the shipped constraint from [references/capabilities.md](./references/capabilities.md) instead of approximating a solution.
+- If the user asks for unsupported routes or token mappings, stop and cite the shipped constraint from `references/capabilities.md` instead of approximating a solution.
 - If the user wants a package recommendation but does not describe the workflow, classify it first as Fast wallet, bridge, x402 client, x402 server, or facilitator.
 - If the user asks for AllSet chains named `ethereum-sepolia` or `arbitrum-sepolia`, translate that request back to the shipped AllSet chain keys `ethereum` and `arbitrum` before coding.
 - If the user wants end-to-end x402 on `arbitrum-sepolia` or `ethereum-sepolia`, stop and cite the current facilitator limits instead of pretending the full stack supports them.

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,8 +40,8 @@ npx skills add fastxyz/fast-skill
 
 ## Package Map
 
-- `@fastxyz/sdk`: Fast network wallet setup, balances, sends, signing, token lookup, low-level claim submission
-- `@fastxyz/allset-sdk`: bridge flows between Fast and supported EVM routes
+- `@fastxyz/sdk`: `FastProvider`, `FastWallet`, browser/core helpers, config helpers, address and BCS utilities for direct Fast work
+- `@fastxyz/allset-sdk`: Fast <-> EVM bridge flows, intent builders, `AllSetProvider`, EVM wallet/executor helpers
 - `@fastxyz/x402-client`: pay 402-protected APIs
 - `@fastxyz/x402-server`: return 402 requirements and protect routes
 - `@fastxyz/x402-facilitator`: verify and settle x402 payments
@@ -80,15 +80,17 @@ Load a flow playbook when the user asks for an end-to-end scenario:
 
 ### 2. Default to testnets unless the user explicitly asks for mainnet
 
-- `@fastxyz/sdk` defaults to `testnet`.
-- `@fastxyz/allset-sdk` currently exposes testnet-oriented bridge routes.
-- x402 packages list both testnet and mainnet-style networks, but do not move a user to mainnet silently.
+- `@fastxyz/sdk` ships `testnet` and `mainnet` defaults and can also load custom named networks from config.
+- `@fastxyz/allset-sdk` ships bundled testnet routes only: `ethereum` (chain ID `11155111`), `arbitrum` (`421614`), and `base` (`8453`). The bundled mainnet `chains` map is empty.
+- x402 client, server, and facilitator do not expose the same network set. Check [references/capabilities.md](./references/capabilities.md) before promising an end-to-end paid API flow.
 
 ### 3. Treat support limits as code-level constraints
 
 - If a route or token is not in the shipped SDK config, say so clearly before writing code.
 - Do not claim AllSet supports arbitrary EVM to EVM bridging in one call. Cross-chain EVM flows are composed from two legs through Fast.
-- Do not claim x402 auto-bridge works on every EVM network; check the current bridge helper and capability matrix.
+- Do not write against removed Fast examples such as `fast()` or `setup()`. The shipped Fast SDK is provider/wallet based.
+- Do not claim x402 auto-bridge works on every EVM network; the current client helper only resolves the bundled bridge path documented in the capability matrix.
+- Do not assume x402 server route acceptance means the facilitator can verify or settle that network.
 
 ### 4. Respect irreversible operations
 
@@ -102,6 +104,8 @@ Load a flow playbook when the user asks for an end-to-end scenario:
 - If the request only says `x402` or `402`, confirm it is specifically about the FAST `@fastxyz/*` packages before routing here.
 - If the user asks for unsupported routes or token mappings, stop and cite the shipped constraint from [references/capabilities.md](./references/capabilities.md) instead of approximating a solution.
 - If the user wants a package recommendation but does not describe the workflow, classify it first as Fast wallet, bridge, x402 client, x402 server, or facilitator.
+- If the user asks for AllSet chains named `ethereum-sepolia` or `arbitrum-sepolia`, translate that request back to the shipped AllSet chain keys `ethereum` and `arbitrum` before coding.
+- If the user wants end-to-end x402 on `arbitrum-sepolia` or `ethereum-sepolia`, stop and cite the current facilitator limits instead of pretending the full stack supports them.
 - If the user needs more Fast-side USDC and already has a `fast1...` address, prefer offering the hosted ramp link on `https://ramp.fast.xyz` over inventing a custom funding workflow.
 
 ## Working Pattern

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "FAST Skill"
   short_description: "Route FAST SDK, bridge, and x402 package tasks"
-  default_prompt: "Use $fast-skill to choose the right FAST package and implement a FAST wallet, bridge, or x402 flow with the shipped @fastxyz packages."
+  default_prompt: "Use $fast-skill to choose the right FAST package and implement a FAST wallet, bridge, or x402 flow with the shipped @fastxyz packages. Read bundled local docs from references/*.md and flows/*.md relative to SKILL.md instead of assuming GitHub URLs."
 
 policy:
   allow_implicit_invocation: true

--- a/flows/chain-to-chain-via-fast.md
+++ b/flows/chain-to-chain-via-fast.md
@@ -61,9 +61,10 @@ Wait until the destination EVM wallet actually receives the funds before treatin
 
 - explain the two-leg model to the user
 - verify support for both legs before implementing
+- bundled AllSet chain keys are `ethereum`, `arbitrum`, and `base`
 - the example shows Arbitrum -> Fast -> Base, but any route still needs both legs shipped in the current SDK config
 - wait for the deposit leg to settle on Fast before starting the withdrawal leg
 - wait for the withdrawal leg to settle on the destination EVM chain before treating the transfer as complete
-- use `@fastxyz/allset-sdk/node` for execution examples
+- use `@fastxyz/allset-sdk/node` for explicit runtime examples; the root package currently re-exports the same runtime APIs too
 - the intermediate Fast address should be the same wallet that signs the withdrawal leg
 - do not hide timing or relayer risk

--- a/flows/evm-to-fast-deposit.md
+++ b/flows/evm-to-fast-deposit.md
@@ -38,6 +38,7 @@ const result = await allset.sendToFast({
 
 - `to` must be `fast1...`
 - `amount` is raw base units
-- use `@fastxyz/allset-sdk/node` for runtime execution; the root package is pure-helper only
+- bundled AllSet chain keys are `ethereum`, `arbitrum`, and `base`
+- use `@fastxyz/allset-sdk/node` for explicit runtime imports; the root package currently re-exports the same runtime APIs too
 - if approval is needed, the executor will handle it before deposit
 - unsupported token mappings should be called out before writing code

--- a/flows/fast-to-evm-withdraw.md
+++ b/flows/fast-to-evm-withdraw.md
@@ -33,5 +33,6 @@ const result = await allset.sendToExternal({
 
 - `to` must be `0x...`
 - `amount` is raw base units
-- use `@fastxyz/allset-sdk/node` for runtime execution; the root package is pure-helper only
+- bundled AllSet chain keys are `ethereum`, `arbitrum`, and `base`
+- use `@fastxyz/allset-sdk/node` for explicit runtime imports; the root package currently re-exports the same runtime APIs too
 - withdrawal may fail at the relayer leg even after the Fast-side action is created

--- a/flows/fast-to-fast-payment.md
+++ b/flows/fast-to-fast-payment.md
@@ -5,31 +5,33 @@ Use `@fastxyz/sdk` for direct Fast transfers.
 ## Steps
 
 1. Install `@fastxyz/sdk`
-2. Create the client on `testnet` unless the user explicitly asked for mainnet
-3. Call `setup()` once
+2. Create a `FastProvider` on `testnet` unless the user explicitly asked for mainnet
+3. Load or create a `FastWallet`
 4. Check balance
 5. Call `send({ to, amount, token? })`
 
 ## Example
 
 ```ts
-import { fast } from '@fastxyz/sdk';
+import { FastProvider, FastWallet } from '@fastxyz/sdk';
 
-const f = fast({ network: 'testnet' });
+const provider = new FastProvider({ network: 'testnet' });
+const wallet = await FastWallet.fromKeyfile({ key: 'default' }, provider);
 
-await f.setup();
-
-const before = await f.balance();
-const sent = await f.send({
+const before = await wallet.balance('FAST');
+const sent = await wallet.send({
   to: 'fast1recipient...',
   amount: '1.0',
+  token: 'FAST',
 });
 
-console.log(before, sent);
+console.log(before, sent.txHash, sent.explorerUrl);
 ```
 
 ## Checks
 
 - recipient must be `fast1...`
 - amount is a human-readable string
+- the native token symbol is `FAST`
+- do not write new examples around removed `fast()` / `setup()` helpers
 - do not proceed if the user has not confirmed the recipient

--- a/flows/top-up-fast-wallet-via-ramp.md
+++ b/flows/top-up-fast-wallet-via-ramp.md
@@ -19,26 +19,24 @@ implementation instead of an interactive top-up path.
 Base URL:
 
 ```text
-https://ramp.fast.xyz
+https://ramp.fast.xyz/
 ```
 
 Parameters:
 
-- `fastAddress`: preferred Fast receiver wallet address query parameter
-- `depositWalletAddress`: accepted alias for the same Fast receiver wallet address
+- `to`: Fast receiver wallet address query parameter
 - no amount prefill is currently documented for the hosted root flow
 
 Examples:
 
 ```text
-https://ramp.fast.xyz?fastAddress=fast1...
-https://ramp.fast.xyz?depositWalletAddress=fast1...
+https://ramp.fast.xyz/?to=fast1...
 ```
 
 ## Agent Behavior
 
 1. Confirm or derive the user's Fast address.
-2. If the Fast address is known, prefer a direct link with `fastAddress`.
+2. If the Fast address is known, prefer a direct link with `to`.
 3. If the Fast address is not known, send the bare hosted ramp link and tell the user they can enter the receiver wallet address on the page.
 4. Tell the user to open the hosted ramp link and complete the payment in the browser.
 5. Do not claim the agent can complete KYC, card entry, or the purchase itself.
@@ -49,7 +47,7 @@ https://ramp.fast.xyz?depositWalletAddress=fast1...
 Keep the language simple and operational:
 
 - say the link tops up Fast-side USDC to their `fast1...` wallet
-- say `fastAddress` fills the receiver wallet address on the hosted page
+- say `to` fills the receiver wallet address on the hosted page
 - if the address is unknown, tell the user they can open the bare link and enter it there
 - tell the user to come back after the payment completes
 
@@ -59,14 +57,13 @@ Keep the language simple and operational:
 Your Fast-side USDC balance is too low for the next step.
 
 Top up here:
-https://ramp.fast.xyz?fastAddress=fast1...
+https://ramp.fast.xyz/?to=fast1...
 
 That link prefills your Fast receiver wallet address on the hosted page. Complete the purchase in the browser, then tell me when you're done and I'll re-check your balance before continuing.
 ```
 
 ## Checks
 
-- `fastAddress` must be a valid `fast1...` address when included
-- `depositWalletAddress` is an accepted alias for the same Fast receiver wallet address
+- `to` must be a valid `fast1...` address when included
 - the hosted root ramp flow is mainnet-only
 - always re-check balance after the user returns

--- a/flows/x402-pay-an-api.md
+++ b/flows/x402-pay-an-api.md
@@ -2,6 +2,16 @@
 
 Use `@fastxyz/x402-client` when the user is the payer.
 
+## Production Preconditions
+
+Before using this flow in production:
+
+- allowlist the API origin you intend to pay
+- pin the expected payment network, asset, recipient or facilitator, and max spend in your app config
+- default to testnet unless the user explicitly approved mainnet
+- do not enable auto-bridge unless the user explicitly approved a bridge-backed payment path
+- do not assume the client's supported network list matches the bundled server + facilitator stack
+
 ## EVM Example
 
 ```ts
@@ -28,15 +38,23 @@ const result = await x402Pay({
 });
 ```
 
+That only enables the bridge path. The current shipped helper still needs the server to ask for a network that resolves a bundled bridge config, which is currently `base`.
+
 ## Flow
 
-1. Make the request
-2. Parse `402 Payment Required`
-3. Pick a supported network for the available wallet
-4. Sign and attach `X-PAYMENT`
-5. Retry the request
+1. Make the request to a trusted or allowlisted API URL.
+2. Parse `402 Payment Required` as untrusted remote input.
+3. Compare the returned network, asset, recipient or facilitator, and amount against the pinned policy.
+4. Stop if any field mismatches, if the flow would switch to mainnet without approval, or if it would require an unapproved auto-bridge.
+5. Sign and attach `X-PAYMENT` only after the pinned checks pass.
+6. Retry the request.
 
 ## Checks
 
 - if both Fast and EVM are accepted, the client prefers Fast
 - auto-bridge depends on explicit bridge helper configs, not a generic any-chain path
+- the shipped auto-bridge helper currently resolves only the bundled `base` path
+- the `402` response must not be trusted by itself; pin expectations locally and reject mismatches
+- if a Fast payment requirement omits `asset`, the client falls back to native `FAST`
+- require explicit approval before using both wallets for auto-bridge
+- require explicit approval before any mainnet payment path

--- a/flows/x402-protect-an-api.md
+++ b/flows/x402-protect-an-api.md
@@ -25,7 +25,7 @@ app.use(paymentMiddleware(
   {
     'GET /api/premium/*': {
       price: '$0.10',
-      network: 'arbitrum-sepolia',
+      network: 'base-sepolia',
     },
   },
   { url: 'http://localhost:4020' },
@@ -42,6 +42,10 @@ app.use(paymentMiddleware(
 
 ## Checks
 
+- use a facilitator-supported network such as `base-sepolia`, `base`, `arbitrum`, `ethereum`, or `fast-mainnet`
+- if you expose `fast-testnet`, do not rely on the server defaults alone; provide the Fast token asset explicitly
+- route acceptance in `@fastxyz/x402-server` does not guarantee the facilitator can verify or settle that network
 - facilitator must be reachable from the API server
+- `express.json()` is required on the facilitator process
 - facilitator wallet must hold gas on EVM settlement networks
 - Fast payments verify differently from EVM authorizations

--- a/references/allset-sdk.md
+++ b/references/allset-sdk.md
@@ -10,7 +10,7 @@ npm install @fastxyz/allset-sdk
 
 Add `@fastxyz/sdk` too when the workflow needs a Fast wallet for Fast -> EVM withdrawals or intent execution.
 
-## Public API
+## Entrypoints
 
 ```ts
 import {
@@ -18,6 +18,7 @@ import {
   buildTransferIntent,
   buildExecuteIntent,
   buildDepositBackIntent,
+  buildRevokeIntent,
 } from '@fastxyz/allset-sdk';
 
 import {
@@ -27,32 +28,35 @@ import {
 } from '@fastxyz/allset-sdk/node';
 ```
 
-- Root `@fastxyz/allset-sdk`: pure helpers only
-- `@fastxyz/allset-sdk/node`: provider, executor, wallet, bridge execution, config access
-- `AllSetProvider`: read config and execute supported bridge legs
-- `createEvmWallet(...)`: create or load an EVM account
-- `createEvmExecutor(account, rpcUrl, chainId)`: create viem clients for approvals and deposits
-- `buildDepositTransaction(...)`: plan an EVM -> Fast deposit without node-only runtime helpers
+- Root `@fastxyz/allset-sdk` currently re-exports both pure helpers and the node/runtime APIs
+- `@fastxyz/allset-sdk/node` is still the clearest explicit runtime import path
+- `@fastxyz/allset-sdk/browser` and `@fastxyz/allset-sdk/core` are the pure-helper surfaces
 
 ## Supported Directions
 
 - EVM -> Fast deposit
 - Fast -> EVM withdraw
+- Fast -> EVM intent execution
 
 This SDK does not expose a single EVM -> EVM bridge call. Cross-chain EVM movement is composed from two legs through Fast.
 
 ## Current Support Limits
 
-- Network posture: testnet-focused
-- Root import does not expose `AllSetProvider` or `createEvmExecutor`
-- Node/runtime bridge config currently ships testnet routes for `arbitrum`, `ethereum`, and `base`
-- Mainnet config path exists, but bundled mainnet chain config is empty
-- Token mapping actually shipped today is `USDC`, with `fastUSDC` and `testUSDC` accepted as Fast-side aliases
-- Amounts are raw base-unit strings such as `'1000000'` for 1 USDC
+- Bundled bridge config is testnet-only
+- Shipped chain keys are `ethereum`, `arbitrum`, and `base`
+- Bundled chain IDs are:
+  - `ethereum` -> `11155111`
+  - `arbitrum` -> `421614`
+  - `base` -> `8453`
+- Bundled mainnet config exists, but its `chains` map is empty
+- `createEvmExecutor(...)` only supports chain IDs `11155111`, `421614`, and `8453`
+- Bundled token mapping is `USDC`, with `fastUSDC` and `testUSDC` normalized to the Fast-side USDC route
+- Amounts are raw 6-decimal base-unit strings such as `'1000000'` for 1 USDC
+- Hard cutover: do not call AllSet with chain names like `arbitrum-sepolia` or `ethereum-sepolia`. The shipped SDK keys are `arbitrum` and `ethereum`.
 
 ## EVM To Fast Deposit
 
-Use the node entrypoint for execution:
+Use the explicit runtime entrypoint for execution:
 
 ```ts
 import { AllSetProvider, createEvmExecutor, createEvmWallet } from '@fastxyz/allset-sdk/node';
@@ -78,7 +82,7 @@ const result = await allset.sendToFast({
 
 ## Fast To EVM Withdraw
 
-Use a Fast wallet plus the node entrypoint:
+Use a Fast wallet plus the explicit runtime entrypoint:
 
 ```ts
 import { FastProvider, FastWallet } from '@fastxyz/sdk';
@@ -98,6 +102,28 @@ const result = await allset.sendToExternal({
 });
 ```
 
+## Intent Execution
+
+```ts
+import { FastProvider, FastWallet } from '@fastxyz/sdk';
+import { AllSetProvider } from '@fastxyz/allset-sdk/node';
+import { buildTransferIntent } from '@fastxyz/allset-sdk';
+
+const fastProvider = new FastProvider({ network: 'testnet' });
+const fastWallet = await FastWallet.fromKeyfile({ key: 'default' }, fastProvider);
+const allset = new AllSetProvider({ network: 'testnet' });
+
+const result = await allset.executeIntent({
+  chain: 'arbitrum',
+  fastWallet,
+  token: 'fastUSDC',
+  amount: '1000000',
+  intents: [
+    buildTransferIntent('0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d', '0xRecipient'),
+  ],
+});
+```
+
 ## Failure Modes To Watch
 
 - `INVALID_PARAMS`: missing `evmClients` or `fastWallet`
@@ -105,6 +131,7 @@ const result = await allset.sendToExternal({
 - `TOKEN_NOT_FOUND`: token mapping not shipped for that route
 - `UNSUPPORTED_OPERATION`: route is not Fast <-> EVM or the EVM chain is not in the current shipped config
 - `TX_FAILED`: approval, deposit, relayer leg, or other downstream bridge execution failed
+- user-supplied mainnet/custom deployments need caller-provided config instead of the bundled defaults
 
 ## Use This Instead Of Other FAST Packages When
 

--- a/references/capabilities.md
+++ b/references/capabilities.md
@@ -4,74 +4,81 @@ Use this file to decide which FAST package owns a request and whether the reques
 
 ## Package Selection
 
-| Package | Use it for | Do not use it for |
-|---|---|---|
-| `@fastxyz/sdk` | Fast wallet setup, balance checks, sends, message signing, token metadata, low-level claim submission | EVM execution, bridging, x402 paywall logic |
-| `@fastxyz/allset-sdk` | Fast <-> EVM bridge flows | Generic Fast wallet work or arbitrary EVM <-> EVM routing |
-| `@fastxyz/x402-client` | Paying 402-protected APIs | Protecting routes or running settlement infra |
-| `@fastxyz/x402-server` | Returning 402 requirements, route protection, payment verification hooks | Signing client payments or settling on-chain by itself |
-| `@fastxyz/x402-facilitator` | Verifying and settling x402 payments | Wallet UX, bridge UX, or general API middleware |
+- `@fastxyz/sdk`: direct Fast wallet/provider work, browser-safe Fast helpers, config/address/BCS utilities
+- `@fastxyz/allset-sdk`: Fast <-> EVM bridge legs and intent execution
+- `@fastxyz/x402-client`: payer-side HTTP 402 handling and payment retries
+- `@fastxyz/x402-server`: 402 payload creation, route protection, and facilitator calls
+- `@fastxyz/x402-facilitator`: payment verification and EVM settlement
 
 ## Current Hard Limits
 
 ### Fast SDK
 
 - Package: `@fastxyz/sdk`
-- Networks: `testnet`, `mainnet`
-- Default: `testnet`
-- Main surface: `fast({ network? })`
-- Safe assumption: use this for direct Fast work unless the user explicitly needs a bridge or x402 flow
+- Current surface is provider/wallet based. The old `fast()` / `setup()` wrapper is not in the shipped package.
+- Root package is the Node entrypoint. Use `@fastxyz/sdk/browser` for browser-safe provider helpers and `@fastxyz/sdk/core` for pure helpers.
+- Built-in networks: `testnet`, `mainnet`
+- Custom named networks are allowed when config provides RPC and optionally explorer / network ID metadata.
+- Bundled token symbols currently resolve `FAST` and `testUSDC` on `testnet`, and `FAST` plus `fastUSDC` on `mainnet`.
 
 ### AllSet SDK
 
 - Package: `@fastxyz/allset-sdk`
-- Current network posture: testnet-focused
-- Entrypoints:
-  - `@fastxyz/allset-sdk` for pure deposit planning and intent builders
-  - `@fastxyz/allset-sdk/node` for `AllSetProvider`, `createEvmWallet`, and `createEvmExecutor`
+- Root package currently re-exports runtime APIs. `@fastxyz/allset-sdk/node` is still the clearest explicit runtime import path.
 - Directions supported in one call:
-  - EVM -> Fast deposit
-  - Fast -> EVM withdraw
-- EVM chains in current bundled testnet config: `arbitrum`, `ethereum`, `base`
-- Token mapping actually shipped today: `USDC`, with `fastUSDC` and `testUSDC` accepted as Fast-side aliases
-- Important caveat: bundled mainnet config is empty. Do not imply bundled mainnet bridge support.
-- Amounts are passed as raw base-unit strings, not human decimal strings
+  - EVM -> Fast deposit via `sendToFast(...)`
+  - Fast -> EVM withdraw via `sendToExternal(...)`
+  - Fast -> EVM intent execution via `executeIntent(...)`
+- Bundled bridge config is testnet-only:
+  - `ethereum` -> chain ID `11155111`
+  - `arbitrum` -> chain ID `421614`
+  - `base` -> chain ID `8453`
+- Bundled mainnet `chains` config is empty. Do not imply turnkey bundled mainnet routing.
+- `createEvmExecutor(...)` only accepts chain IDs `11155111`, `421614`, and `8453`.
+- Bundled token mapping is `USDC`, with `fastUSDC` and `testUSDC` normalized to that route on Fast-side operations.
+- Amounts are raw 6-decimal base-unit strings, not human decimal strings.
 
 ### x402 Client
 
 - Package: `@fastxyz/x402-client`
 - Primary API: `x402Pay(...)`
-- Payment networks listed by the SDK:
-  - `fast-testnet`, `fast-mainnet`
-  - `arbitrum-sepolia`, `arbitrum`
-  - `base-sepolia`, `base`
-  - `ethereum`
-- Auto-bridge caveat: the bridge helper currently has explicit configs for `arbitrum-sepolia` and `base-sepolia`
-- If the user wants auto-bridge, provide both a Fast wallet and an EVM wallet
+- Helper exports also include `parse402Response(...)`, `buildPaymentHeader(...)`, `parsePaymentHeader(...)`, `FAST_NETWORKS`, `EVM_NETWORKS`, `getBridgeConfig(...)`, `getFastBalance(...)`, and `bridgeFastusdcToUsdc(...)`.
+- Networks the client can sign today:
+  - Fast: `fast-testnet`, `fast-mainnet`
+  - EVM: `ethereum-sepolia`, `arbitrum-sepolia`, `arbitrum`, `base-sepolia`, `base`
+- If both Fast and EVM are accepted and both wallets are present, the client prefers the Fast path.
+- The helper does not pin the remote `402` payload for you. Treat network, asset, recipient, and amount as untrusted input.
+- Auto-bridge is not generic. In the current shipped helper, only the bundled `base` path resolves a bridge config.
 
 ### x402 Server
 
 - Package: `@fastxyz/x402-server`
-- Primary API: `paymentMiddleware(...)`
+- Primary APIs: `paymentMiddleware(...)` and `paywall(...)`
+- Low-level helpers are also exported: `createPaymentRequirement(...)`, `createPaymentRequired(...)`, `verifyPayment(...)`, `settlePayment(...)`, `verifyAndSettle(...)`, `parsePrice(...)`, `getNetworkConfig(...)`, `encodePayload(...)`, `decodePayload(...)`
 - Role: create 402 requirements and forward verify/settle work to a facilitator
-- Supported network config baked into the package:
-  - `fast-testnet`, `fast-mainnet`
-  - `arbitrum-sepolia`, `arbitrum`
-  - `base-sepolia`, `base`
+- The only hard rejection is the deprecated alias `fast`. Route acceptance is broader than the real built-in config.
+- Built-in `NETWORK_CONFIGS` currently resolve concrete asset metadata for:
+  - `fast-mainnet`
+  - `arbitrum`
   - `ethereum`
-- Unknown networks fall back to a generic asset config. Do not invent support just because the helper has a fallback.
+  - `base`
+  - `base-sepolia`
+- Any other network name falls back to a generic asset `0x0000000000000000000000000000000000000000` with 6 decimals.
+- Do not describe `fast-testnet`, `arbitrum-sepolia`, or `ethereum-sepolia` as turnkey server defaults today.
 
 ### x402 Facilitator
 
 - Package: `@fastxyz/x402-facilitator`
 - Role: verify payments and settle EVM authorizations
-- Supported EVM chain config in code:
-  - `arbitrum-sepolia`, `arbitrum`
-  - `base-sepolia`, `base`
-  - `ethereum`, `ethereum-sepolia`
-- Supported Fast network config in code:
-  - `fast-testnet`, `fast-mainnet`
-- Settlement only applies to EVM payments. Fast payments are already on-chain.
+- Fast networks in code: `fast-testnet`, `fast-mainnet`
+- Current built-in EVM chain map loads:
+  - `arbitrum`
+  - `ethereum`
+  - `base`
+  - `base-sepolia`
+- `arbitrum-sepolia` and `ethereum-sepolia` currently fail facilitator verify/settle with `invalid_network`.
+- `evmPrivateKey` is required for EVM settlement. Fast settlement is already on-chain and becomes a no-op.
+- `FacilitatorConfig.chains` is declared in the public type, but the current verify/settle path still uses the built-in chain map.
 
 ## Decision Rules
 
@@ -79,6 +86,7 @@ Use this file to decide which FAST package owns a request and whether the reques
 - If the user wants Fast <-> EVM movement, use `@fastxyz/allset-sdk`.
 - If the user wants to pay for an API, use `@fastxyz/x402-client`.
 - If the user wants to sell API access, use `@fastxyz/x402-server` and usually `@fastxyz/x402-facilitator`.
+- If the user wants an end-to-end x402 stack, verify the facilitator network first instead of trusting the client or server surface alone.
 - If the user wants chain-to-chain movement, explain that it is composed:
   1. deposit into Fast
   2. withdraw out of Fast
@@ -87,7 +95,12 @@ Use this file to decide which FAST package owns a request and whether the reques
 
 Stop and call out the limitation before coding when:
 
+- the user asks for Fast SDK code built around `fast()` or `setup()`
 - the user asks for an AllSet route that is not Fast <-> EVM
+- the user asks for AllSet chain names like `ethereum-sepolia` or `arbitrum-sepolia` instead of the shipped chain keys `ethereum` and `arbitrum`
 - the requested AllSet token is not the shipped `USDC`, `fastUSDC`, or `testUSDC` mapping
 - the request assumes all x402 networks support auto-bridge
+- the request assumes the x402 client network list equals end-to-end server + facilitator support
+- the request assumes `fast-testnet` has a turnkey server-side stablecoin default without explicit asset configuration
+- the remote `402` payload asks for a network, asset, recipient, facilitator, or amount that does not match the locally pinned payment policy
 - the request assumes a single umbrella x402 package surface when the codebase actually uses role-specific packages

--- a/references/fast-sdk.md
+++ b/references/fast-sdk.md
@@ -8,64 +8,125 @@ Use this when the request is purely about Fast network wallets, balances, transf
 npm install @fastxyz/sdk
 ```
 
-## Public API
+## Entrypoints
 
 ```ts
-import { fast, FastError } from '@fastxyz/sdk';
-
-const f = fast({ network: 'testnet' });
+import { FastProvider, FastWallet, FastError } from '@fastxyz/sdk';
+import { FastProvider as BrowserFastProvider } from '@fastxyz/sdk/browser';
+import { encodeFastAddress, decodeFastAddress } from '@fastxyz/sdk/core';
 ```
 
-- `fast({ network?, rpcUrl? })`: create a client
-- `FastError`: typed operational errors with `code`, `message`, and optional `note`
+- `@fastxyz/sdk`: Node runtime entrypoint with `FastProvider`, `FastWallet`, config helpers, address helpers, and BCS / certificate utilities
+- `@fastxyz/sdk/browser`: browser-safe `FastProvider` plus shared helpers, with no keyfile support
+- `@fastxyz/sdk/core`: pure helpers only
 
-## Standard Flow
+Hard cutover: do not write against an old `fast()` / `setup()` wrapper. The shipped package is provider/wallet based.
+
+## Standard Node Flow
 
 ```ts
-const f = fast({ network: 'testnet' });
+import { FastProvider, FastWallet } from '@fastxyz/sdk';
 
-const { address } = await f.setup();
-const balance = await f.balance();
-const sent = await f.send({ to: 'fast1...', amount: '1.0' });
+const provider = new FastProvider({ network: 'testnet' });
+const wallet = await FastWallet.fromKeyfile({ key: 'default' }, provider);
+
+const balance = await wallet.balance('FAST');
+const sent = await wallet.send({
+  to: 'fast1recipient...',
+  amount: '1.0',
+  token: 'FAST',
+});
+
+console.log(wallet.address);
+console.log(balance.amount);
+console.log(sent.txHash, sent.explorerUrl);
 ```
 
-Call `setup()` before everything else. It creates or loads the local wallet and returns the `fast1...` address.
+## Browser-Safe Flow
 
-## Methods That Matter
+```ts
+import { FastProvider, getCertificateHash } from '@fastxyz/sdk/browser';
 
-- `setup()`: create or load the wallet
-- `balance({ token? })`: get native `SET` or a token by held symbol or token id
-- `send({ to, amount, token? })`: send native `SET` or a custom token
-- `sign({ message })`: sign with the local Ed25519 key
-- `verify({ message, signature, address })`: verify a signature
-- `tokens()`: list held tokens and balances
-- `tokenInfo({ token })`: fetch metadata for a held symbol or token id
-- `submit({ recipient, claim })`: low-level custom claim submission
-- `exportKeys()`: return public key and address only
-- `address`: current wallet address after setup
+const provider = new FastProvider({ network: 'testnet' });
+const balance = await provider.getBalance('fast1recipient...', 'FAST');
+const certificate = await provider.getCertificateByNonce('fast1recipient...', 1);
 
-## Important Data Rules
+console.log(balance.amount);
+if (certificate) {
+  console.log(getCertificateHash(certificate));
+}
+```
+
+## APIs That Matter
+
+Provider:
+
+- `new FastProvider({ network?, networkId?, rpcUrl?, explorerUrl?, networks?, tokens? })`
+- `getBalance(address, token?)`
+- `getTokens(address)`
+- `getTokenInfo(token)`
+- `getAccountInfo(address)`
+- `getTransactionCertificates(address, fromNonce, limit)`
+- `getCertificateByNonce(address, nonce)`
+- `submitTransaction(envelope)`
+- `faucetDrip({ recipient, amount, token? })`
+- `getExplorerUrl(txHash?)`
+- `resolveKnownToken(token)`, `getKnownTokens()`, `getKnownNetworks()`, `getNetworkId()`
+
+Wallet:
+
+- `FastWallet.fromKeyfile(pathOrOpts, provider)`
+- `FastWallet.fromPrivateKey(privateKey, provider)`
+- `FastWallet.generate(provider)`
+- `saveToKeyfile(path)`
+- `balance(token?)`
+- `tokens()`
+- `send({ to, amount, token? })`
+- `sign({ message })`
+- `verify({ message, signature, address })`
+- `submit({ claim })`
+- `exportKeys()`
+
+Shared helpers:
+
+- `encodeFastAddress`, `fastAddressToBytes`, `decodeFastAddress`
+- `getNetworkInfo`, `getAllNetworks`, `resolveKnownFastToken`, `getAllTokens`, `getDefaultRpcUrl`, `getExplorerUrl`
+- `hashTransaction`, `serializeVersionedTransaction`, `decodeTransactionEnvelope`, `getTransferDetails`
+- `FAST_TOKEN_ID`, `FAST_DECIMALS`, `FAST_NETWORK_IDS`
+
+## Config And Data Rules
 
 - Default network is `testnet`. Only use `mainnet` if the user explicitly asks.
-- Transfer amounts are human-readable strings, for example `'1.5'`.
+- Node config precedence:
+  1. constructor overrides
+  2. `~/.fast/networks.json` and `~/.fast/tokens.json`
+  3. bundled defaults
+  4. hardcoded fallbacks
+- Browser config omits the `~/.fast/*` layer and uses constructor overrides plus bundled defaults.
+- Built-in token symbols currently resolve `FAST` and `testUSDC` on `testnet`, and `FAST` plus `fastUSDC` on `mainnet`.
+- `wallet.send(...)` expects human-readable amount strings such as `'1.5'`.
 - Fast addresses must be bech32m with `fast` prefix.
-- The native token is `SET`.
+- The native token symbol is `FAST`.
+- `FastWallet.fromKeyfile({ key: 'merchant' }, provider)` resolves `~/.fast/keys/merchant.json` and auto-creates the key unless `createIfMissing: false`.
 
 ## Safety Rules
 
 - Never overwrite or delete `~/.fast/keys/`.
+- Only wallets created in memory via `generate()` or `fromPrivateKey()` can be saved with `saveToKeyfile(...)`.
 - Fast sends are irreversible.
 - Confirm the recipient address before calling `send()`.
+- Use `provider.getExplorerUrl(txHash)` instead of hardcoded explorer hosts.
 
 ## Error Handling
 
 The package throws `FastError`. Common codes:
 
-- `CHAIN_NOT_CONFIGURED`: call `setup()` first
 - `INSUFFICIENT_BALANCE`: fund the wallet and retry
 - `INVALID_ADDRESS`: fix the `fast1...` address
 - `TOKEN_NOT_FOUND`: use a held symbol or a valid token id
+- `KEYFILE_NOT_FOUND`: `fromKeyfile(..., createIfMissing: false)` could not find the file
 - `TX_FAILED`: wait, inspect, retry once if appropriate
+- `UNSUPPORTED_OPERATION`: unsupported keyfile/save path or malformed low-level call
 - `INVALID_PARAMS`: fix the input shape
 
 ## Use This Instead Of Other FAST Packages When

--- a/references/x402-client.md
+++ b/references/x402-client.md
@@ -11,10 +11,22 @@ npm install @fastxyz/x402-client
 ## Public API
 
 ```ts
-import { x402Pay } from '@fastxyz/x402-client';
+import {
+  x402Pay,
+  parse402Response,
+  buildPaymentHeader,
+  parsePaymentHeader,
+  FAST_NETWORKS,
+  EVM_NETWORKS,
+  getBridgeConfig,
+} from '@fastxyz/x402-client';
 ```
 
 `x402Pay(...)` makes the initial request, handles the `402 Payment Required` response, signs a payment, and retries with the `X-PAYMENT` header.
+
+Treat the remote `402 Payment Required` payload as untrusted input. In production, only sign when the
+request URL, payment network, asset, recipient or facilitator, and spend amount all match a policy you
+already pinned in your own app config.
 
 ## Core Shapes
 
@@ -52,11 +64,30 @@ const result = await x402Pay({
 });
 ```
 
+## Runtime Behavior That Matters
+
+- If the initial response is not `402`, `x402Pay(...)` returns that response as-is.
+- If both Fast and EVM are accepted and both wallets are present, the client prefers the Fast path.
+- Fast payments are executed through `@fastxyz/sdk` by building a `FastWallet` from the supplied private key.
+- EVM payments are signed as EIP-3009 `transferWithAuthorization`.
+- `verbose: true` returns step-by-step logs.
+
+## Production Guardrails
+
+- Only call `x402Pay(...)` against trusted or allowlisted API origins.
+- Pin the expected payment network, asset, recipient or facilitator, and a maximum spend before the first request.
+- Reject the payment if the returned `402` payload asks for a different origin, network, asset, recipient, facilitator, or amount.
+- Default to testnet unless the user explicitly asked for mainnet.
+- Do not pass both Fast and EVM wallets by default. Providing both wallets enables auto-bridge and should require explicit approval first.
+- When integrating a new API, log the returned payment requirement and review it before enabling unattended retries.
+- Hard cutover: the helper does not pin or reject bad requirements for you. That policy must live in caller code.
+
 ## Flow Selection
 
 - If the 402 response accepts Fast and you provided a Fast wallet, the client prefers the Fast path.
 - If the 402 response accepts EVM and you provided an EVM wallet, the client can sign an EIP-3009 payment.
-- If EVM payment needs balance and both wallets are present, the client can attempt auto-bridge.
+- If EVM payment needs balance and both wallets are present, the client can attempt auto-bridge after the caller explicitly approves that funding path.
+- If a Fast payment requirement omits `asset`, the client falls back to sending native `FAST`.
 
 ## Auto-Bridge Caveat
 
@@ -66,7 +97,10 @@ Provide both wallets to enable auto-bridge:
 wallet: [fastWallet, evmWallet]
 ```
 
-Current bridge helper configs are explicit, not generic. Treat auto-bridge as available only on the networks wired into the helper today, currently `arbitrum-sepolia` and `base-sepolia`.
+Current bridge helper configs are explicit, not generic. In the shipped helper, only the bundled `base` path resolves an AllSet bridge config today.
+
+In production, only provide both wallets after the user confirms the bridge path, source wallet, destination
+network, and spend ceiling. Otherwise pass a single wallet so the payment either succeeds on that network or fails closed.
 
 ## Result Shape
 
@@ -85,9 +119,11 @@ Use `verbose: true` to include step-by-step logs.
 ## Supported Payment Networks
 
 - `fast-testnet`, `fast-mainnet`
+- `ethereum-sepolia`
 - `arbitrum-sepolia`, `arbitrum`
 - `base-sepolia`, `base`
-- `ethereum`
+
+The client can sign those EVM networks, but that does not mean the bundled server + facilitator stack can verify and settle all of them end-to-end.
 
 ## Use This Instead Of Other FAST Packages When
 

--- a/references/x402-facilitator.md
+++ b/references/x402-facilitator.md
@@ -13,8 +13,11 @@ npm install @fastxyz/x402-facilitator
 ```ts
 import {
   createFacilitatorServer,
+  createFacilitatorRoutes,
   verify,
   settle,
+  SUPPORTED_EVM_NETWORKS,
+  SUPPORTED_FAST_NETWORKS,
 } from '@fastxyz/x402-facilitator';
 ```
 
@@ -43,31 +46,37 @@ Fast payments do not need settlement because the payment is already on-chain.
 ## Use As A Library
 
 - `verify(paymentPayload, paymentRequirement)`
-- `settle(paymentPayload, paymentRequirement, evmPrivateKey)`
+- `settle(paymentPayload, paymentRequirement, config)`
 
 ## Config Requirements
 
 - `evmPrivateKey`: required for EVM settlement, because the facilitator pays gas
 - `fastRpcUrl`: optional override for Fast verification
-- `chains`: optional custom EVM chain config map
+- `committeePublicKeys`: optional override for trusted Fast committee keys
+- `chains`: declared in the public type, but the current verify / settle path still uses the built-in chain map
 
 ## Supported Networks In Code
 
 EVM:
 
-- `arbitrum-sepolia`, `arbitrum`
-- `base-sepolia`, `base`
-- `ethereum`, `ethereum-sepolia`
+- `arbitrum`
+- `ethereum`
+- `base`
+- `base-sepolia`
 
 Fast:
 
 - `fast-testnet`, `fast-mainnet`
+
+Hard cutover: `arbitrum-sepolia` and `ethereum-sepolia` are not in the current built-in EVM chain map. `verify(...)` and `settle(...)` return `invalid_network` for them.
 
 ## Operational Rules
 
 - Fund the facilitator wallet with native gas on every EVM network you settle on.
 - Re-verify a payment before settlement.
 - Treat Fast verification and EVM settlement as different concerns.
+- `GET /supported` is the source of truth for the current service surface.
+- The HTTP server accepts either decoded JSON payloads or base64-encoded `paymentPayload` bodies.
 
 ## Good Fit
 

--- a/references/x402-server.md
+++ b/references/x402-server.md
@@ -13,9 +13,16 @@ npm install @fastxyz/x402-server
 ```ts
 import {
   paymentMiddleware,
+  paywall,
+  createPaymentRequirement,
   createPaymentRequired,
+  parsePaymentHeader,
   verifyPayment,
   settlePayment,
+  verifyAndSettle,
+  NETWORK_CONFIGS,
+  parsePrice,
+  getNetworkConfig,
 } from '@fastxyz/x402-server';
 ```
 
@@ -35,7 +42,7 @@ app.use(paymentMiddleware(
   {
     'GET /api/premium/*': {
       price: '$0.10',
-      network: 'arbitrum-sepolia',
+      network: 'base-sepolia',
     },
   },
   { url: 'http://localhost:4020' },
@@ -49,6 +56,8 @@ app.use(paymentMiddleware(
 - parse `X-PAYMENT`
 - call the facilitator to verify payments
 - call the facilitator to settle EVM payments
+- set `X-PAYMENT-RESPONSE` after successful verify / settlement
+- offer `paywall(...)` as a one-config wrapper around `paymentMiddleware(...)`
 
 ## Route Config Notes
 
@@ -65,18 +74,26 @@ Optional config can add:
 
 Price strings can be human-readable like `'$0.10'` or raw like `'100000'`.
 
+`config.asset` overrides the asset address or token id, but decimals and any EIP-3009 metadata still come from the package network config or its fallback.
+
 ## Facilitator Dependency
 
 This package is not the settlement engine. For working payment verification and EVM settlement, run `@fastxyz/x402-facilitator` and point the middleware at its base URL.
 
-## Supported Network Config
+## Built-In Network Caveats
 
-- `fast-testnet`, `fast-mainnet`
-- `arbitrum-sepolia`, `arbitrum`
-- `base-sepolia`, `base`
-- `ethereum`
+- The only hard-rejected alias is `fast`. Most other network strings are accepted by the builder.
+- Built-in `NETWORK_CONFIGS` currently resolve concrete asset metadata for:
+  - `fast-mainnet`
+  - `arbitrum`
+  - `ethereum`
+  - `base`
+  - `base-sepolia`
+- Any other network name falls back to generic asset `0x0000000000000000000000000000000000000000` with 6 decimals.
+- Hard cutover: do not describe `fast-testnet`, `arbitrum-sepolia`, or `ethereum-sepolia` as turnkey defaults in this package today.
+- Route acceptance still does not guarantee that the facilitator can verify or settle that network.
 
-Do not claim arbitrary network support just because the utility layer has a fallback config.
+Use explicit route assets and capability checks when you need anything outside the current built-in config.
 
 ## Good Fit
 


### PR DESCRIPTION
## Summary
- update the Fast SDK references and flows to the current FastProvider/FastWallet surface
- sync AllSet routing and bridge docs to the current shipped exports and bundled route limits
- tighten x402 client/server/facilitator guidance to the actual current network support and guardrails

## Validation
- npm run validate