### PR TITLE
Improve SKILL.md dual-entrypoint doc links

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -13,6 +13,9 @@ compatibility: >
   explicitly asks for mainnet.
 metadata:
   version: 0.2.0
+  canonical_url: https://skill.fast.xyz/skill.md
+  docs_base_url: https://skill.fast.xyz/
+  source_repo: https://github.com/fastxyz/fast-skill
 ---
 
 # FAST Skill
@@ -29,8 +32,9 @@ npx skills add fastxyz/fast-skill
 
 This skill ships its own Markdown docs inside the installed skill directory.
 
-- Treat `references/*.md` and `flows/*.md` as local bundled files, not web URLs.
-- Resolve them relative to this `SKILL.md`.
+- Treat `references/*.md` and `flows/*.md` as bundled docs that travel with this skill.
+- Resolve `./references/...` and `./flows/...` relative to this `SKILL.md`.
+- If this file was loaded from `https://skill.fast.xyz/skill.md`, resolve those same relative paths against `https://skill.fast.xyz/`.
 - Open the file path directly if your runtime does not expose clickable Markdown links.
 - Do not assume GitHub access is required to read these docs.
 
@@ -59,25 +63,25 @@ If an umbrella x402 package is introduced later, treat it as a wrapper. The curr
 
 ## Start Here
 
-Read `references/capabilities.md` first when the request involves multiple packages or unclear support.
+Read [Capabilities](./references/capabilities.md) first when the request involves multiple packages or unclear support.
 
 Then route by task:
 
-- Fast wallet, balance, send, token info, signatures: `references/fast-sdk.md`
-- Bridge between Fast and EVM: `references/allset-sdk.md`
-- Pay for a protected API: `references/x402-client.md`
-- Add payments to an API: `references/x402-server.md`
-- Run verification or settlement infrastructure: `references/x402-facilitator.md`
+- Fast wallet, balance, send, token info, signatures: [FAST SDK reference](./references/fast-sdk.md)
+- Bridge between Fast and EVM: [AllSet SDK reference](./references/allset-sdk.md)
+- Pay for a protected API: [x402 client reference](./references/x402-client.md)
+- Add payments to an API: [x402 server reference](./references/x402-server.md)
+- Run verification or settlement infrastructure: [x402 facilitator reference](./references/x402-facilitator.md)
 
 Load a flow playbook when the user asks for an end-to-end scenario:
 
-- Fast to Fast transfer: `flows/fast-to-fast-payment.md`
-- EVM to Fast deposit: `flows/evm-to-fast-deposit.md`
-- Fast to EVM withdraw: `flows/fast-to-evm-withdraw.md`
-- Top up Fast wallet via hosted ramp: `flows/top-up-fast-wallet-via-ramp.md`
-- Chain to chain via Fast: `flows/chain-to-chain-via-fast.md`
-- Pay an x402 API: `flows/x402-pay-an-api.md`
-- Protect an x402 API: `flows/x402-protect-an-api.md`
+- Fast to Fast transfer: [Fast-to-Fast payment flow](./flows/fast-to-fast-payment.md)
+- EVM to Fast deposit: [EVM-to-Fast deposit flow](./flows/evm-to-fast-deposit.md)
+- Fast to EVM withdraw: [Fast-to-EVM withdraw flow](./flows/fast-to-evm-withdraw.md)
+- Top up Fast wallet via hosted ramp: [Top-up via ramp flow](./flows/top-up-fast-wallet-via-ramp.md)
+- Chain to chain via Fast: [Chain-to-chain via Fast flow](./flows/chain-to-chain-via-fast.md)
+- Pay an x402 API: [x402 pay-an-API flow](./flows/x402-pay-an-api.md)
+- Protect an x402 API: [x402 protect-an-API flow](./flows/x402-protect-an-api.md)
 
 ## Routing Rules
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -114,7 +114,7 @@ Load a flow playbook when the user asks for an end-to-end scenario:
 - If the request only says `x402` or `402`, confirm it is specifically about the FAST `@fastxyz/*` packages before routing here.
 - If the user asks for unsupported routes or token mappings, stop and cite the shipped constraint from `references/capabilities.md` instead of approximating a solution.
 - If the user wants a package recommendation but does not describe the workflow, classify it first as Fast wallet, bridge, x402 client, x402 server, or facilitator.
-- If the user asks for AllSet chains named `ethereum-sepolia` or `arbitrum-sepolia`, translate that request back to the shipped AllSet chain keys `ethereum` and `arbitrum` before coding.
+- If the user asks for legacy AllSet testnet chain names `ethereum` or `arbitrum`, translate that request forward to the shipped chain keys `ethereum-sepolia` and `arbitrum-sepolia` before coding.
 - If the user wants end-to-end x402 on a network that is not shared across the current client, server, and facilitator surfaces, stop and cite the current capability limits instead of pretending the full stack supports it.
 - If the user needs more Fast-side USDC and already has a `fast1...` address, prefer offering the hosted ramp link on `https://ramp.fast.xyz` over inventing a custom funding workflow.
 

--- a/flows/chain-to-chain-via-fast.md
+++ b/flows/chain-to-chain-via-fast.md
@@ -24,7 +24,7 @@ const fastWallet = await FastWallet.fromKeyfile('~/.fast/keys/default.json', fas
 const allset = new AllSetProvider({ network: 'testnet' });
 
 const deposit = await allset.sendToFast({
-  chain: 'arbitrum',
+  chain: 'arbitrum-sepolia',
   token: 'USDC',
   amount: '1000000',
   from: account.address,
@@ -44,7 +44,7 @@ After the deposit settles on Fast, run the withdrawal leg:
 
 const withdraw = await allset.sendToExternal({
   chain: 'base',
-  token: 'fastUSDC',
+  token: 'USDC',
   amount: '1000000',
   from: fastWallet.address,
   to: '0xDestinationAddress',
@@ -61,7 +61,7 @@ Wait until the destination EVM wallet actually receives the funds before treatin
 
 - explain the two-leg model to the user
 - verify support for both legs before implementing
-- bundled AllSet chain keys are `ethereum`, `arbitrum`, and `base`
+- bundled AllSet chain keys are `ethereum-sepolia`, `arbitrum-sepolia`, and `base`
 - the example shows Arbitrum -> Fast -> Base, but any route still needs both legs shipped in the current SDK config
 - wait for the deposit leg to settle on Fast before starting the withdrawal leg
 - wait for the withdrawal leg to settle on the destination EVM chain before treating the transfer as complete

--- a/flows/evm-to-fast-deposit.md
+++ b/flows/evm-to-fast-deposit.md
@@ -25,7 +25,7 @@ const evmClients = createEvmExecutor(
 const allset = new AllSetProvider({ network: 'testnet' });
 
 const result = await allset.sendToFast({
-  chain: 'arbitrum',
+  chain: 'arbitrum-sepolia',
   token: 'USDC',
   amount: '1000000',
   from: account.address,
@@ -38,7 +38,7 @@ const result = await allset.sendToFast({
 
 - `to` must be `fast1...`
 - `amount` is raw base units
-- bundled AllSet chain keys are `ethereum`, `arbitrum`, and `base`
+- bundled AllSet chain keys are `ethereum-sepolia`, `arbitrum-sepolia`, and `base`
 - use `@fastxyz/allset-sdk/node` for explicit runtime imports; the root package currently re-exports the same runtime APIs too
 - if approval is needed, the executor will handle it before deposit
 - unsupported token mappings should be called out before writing code

--- a/flows/fast-to-evm-withdraw.md
+++ b/flows/fast-to-evm-withdraw.md
@@ -20,8 +20,8 @@ const fastWallet = await FastWallet.fromKeyfile('~/.fast/keys/default.json', fas
 const allset = new AllSetProvider({ network: 'testnet' });
 
 const result = await allset.sendToExternal({
-  chain: 'arbitrum',
-  token: 'fastUSDC',
+  chain: 'arbitrum-sepolia',
+  token: 'USDC',
   amount: '1000000',
   from: fastWallet.address,
   to: '0xYourEvmAddress',
@@ -33,6 +33,6 @@ const result = await allset.sendToExternal({
 
 - `to` must be `0x...`
 - `amount` is raw base units
-- bundled AllSet chain keys are `ethereum`, `arbitrum`, and `base`
+- bundled AllSet chain keys are `ethereum-sepolia`, `arbitrum-sepolia`, and `base`
 - use `@fastxyz/allset-sdk/node` for explicit runtime imports; the root package currently re-exports the same runtime APIs too
 - withdrawal may fail at the relayer leg even after the Fast-side action is created

--- a/flows/x402-pay-an-api.md
+++ b/flows/x402-pay-an-api.md
@@ -38,7 +38,7 @@ const result = await x402Pay({
 });
 ```
 
-That only enables the bridge path. The current shipped helper still needs the server to ask for a network that resolves a bundled bridge config, which is currently `base`.
+That only enables the bridge path. The current shipped helper still needs the server to ask for a network that resolves a bundled bridge config, which currently means `ethereum-sepolia`, `arbitrum-sepolia`, or `base`.
 
 ## Flow
 
@@ -53,7 +53,7 @@ That only enables the bridge path. The current shipped helper still needs the se
 
 - if both Fast and EVM are accepted, the client prefers Fast
 - auto-bridge depends on explicit bridge helper configs, not a generic any-chain path
-- the shipped auto-bridge helper currently resolves only the bundled `base` path
+- the shipped auto-bridge helper currently resolves explicit bundled configs for `ethereum-sepolia`, `arbitrum-sepolia`, and `base`
 - the `402` response must not be trusted by itself; pin expectations locally and reject mismatches
 - if a Fast payment requirement omits `asset`, the client falls back to native `FAST`
 - require explicit approval before using both wallets for auto-bridge

--- a/references/allset-sdk.md
+++ b/references/allset-sdk.md
@@ -43,16 +43,16 @@ This SDK does not expose a single EVM -> EVM bridge call. Cross-chain EVM moveme
 ## Current Support Limits
 
 - Bundled bridge config is testnet-only
-- Shipped chain keys are `ethereum`, `arbitrum`, and `base`
+- Shipped chain keys are `ethereum-sepolia`, `arbitrum-sepolia`, and `base`
 - Bundled chain IDs are:
-  - `ethereum` -> `11155111`
-  - `arbitrum` -> `421614`
+  - `ethereum-sepolia` -> `11155111`
+  - `arbitrum-sepolia` -> `421614`
   - `base` -> `8453`
 - Bundled mainnet config exists, but its `chains` map is empty
 - `createEvmExecutor(...)` only supports chain IDs `11155111`, `421614`, and `8453`
 - Bundled token mapping is `USDC`, with `fastUSDC` and `testUSDC` normalized to the Fast-side USDC route
 - Amounts are raw 6-decimal base-unit strings such as `'1000000'` for 1 USDC
-- Hard cutover: do not call AllSet with chain names like `arbitrum-sepolia` or `ethereum-sepolia`. The shipped SDK keys are `arbitrum` and `ethereum`.
+- Hard cutover: do not write new AllSet examples with legacy testnet keys like `arbitrum` or `ethereum`. The shipped SDK keys are `arbitrum-sepolia` and `ethereum-sepolia`.
 
 ## EVM To Fast Deposit
 
@@ -71,7 +71,7 @@ const evmClients = createEvmExecutor(
 const allset = new AllSetProvider({ network: 'testnet' });
 
 const result = await allset.sendToFast({
-  chain: 'arbitrum',
+  chain: 'arbitrum-sepolia',
   token: 'USDC',
   amount: '1000000',
   from: account.address,
@@ -93,8 +93,8 @@ const fastWallet = await FastWallet.fromKeyfile('~/.fast/keys/default.json', fas
 const allset = new AllSetProvider({ network: 'testnet' });
 
 const result = await allset.sendToExternal({
-  chain: 'arbitrum',
-  token: 'fastUSDC',
+  chain: 'arbitrum-sepolia',
+  token: 'USDC',
   amount: '1000000',
   from: fastWallet.address,
   to: '0xYourEvmAddress',
@@ -114,9 +114,9 @@ const fastWallet = await FastWallet.fromKeyfile({ key: 'default' }, fastProvider
 const allset = new AllSetProvider({ network: 'testnet' });
 
 const result = await allset.executeIntent({
-  chain: 'arbitrum',
+  chain: 'arbitrum-sepolia',
   fastWallet,
-  token: 'fastUSDC',
+  token: 'USDC',
   amount: '1000000',
   intents: [
     buildTransferIntent('0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d', '0xRecipient'),

--- a/references/capabilities.md
+++ b/references/capabilities.md
@@ -19,7 +19,7 @@ Use this file to decide which FAST package owns a request and whether the reques
 - Root package is the Node entrypoint. Use `@fastxyz/sdk/browser` for browser-safe provider helpers and `@fastxyz/sdk/core` for pure helpers.
 - Built-in networks: `testnet`, `mainnet`
 - Custom named networks are allowed when config provides RPC and optionally explorer / network ID metadata.
-- Bundled token symbols currently resolve `FAST` and `testUSDC` on `testnet`, and `FAST` plus `fastUSDC` on `mainnet`.
+- Bundled token symbols currently resolve `FAST` and `testUSDC` on `testnet`, and `FAST` plus `USDC` on `mainnet`.
 
 ### AllSet SDK
 
@@ -30,8 +30,8 @@ Use this file to decide which FAST package owns a request and whether the reques
   - Fast -> EVM withdraw via `sendToExternal(...)`
   - Fast -> EVM intent execution via `executeIntent(...)`
 - Bundled bridge config is testnet-only:
-  - `ethereum` -> chain ID `11155111`
-  - `arbitrum` -> chain ID `421614`
+  - `ethereum-sepolia` -> chain ID `11155111`
+  - `arbitrum-sepolia` -> chain ID `421614`
   - `base` -> chain ID `8453`
 - Bundled mainnet `chains` config is empty. Do not imply turnkey bundled mainnet routing.
 - `createEvmExecutor(...)` only accepts chain IDs `11155111`, `421614`, and `8453`.
@@ -48,7 +48,7 @@ Use this file to decide which FAST package owns a request and whether the reques
   - EVM: `ethereum-sepolia`, `arbitrum-sepolia`, `arbitrum`, `base-sepolia`, `base`
 - If both Fast and EVM are accepted and both wallets are present, the client prefers the Fast path.
 - The helper does not pin the remote `402` payload for you. Treat network, asset, recipient, and amount as untrusted input.
-- Auto-bridge is not generic. In the current shipped helper, only the bundled `base` path resolves a bridge config.
+- Auto-bridge is not generic. In the current shipped helper, bridge configs are explicit and currently resolve `ethereum-sepolia`, `arbitrum-sepolia`, and `base`.
 
 ### x402 Server
 
@@ -100,7 +100,7 @@ Stop and call out the limitation before coding when:
 
 - the user asks for Fast SDK code built around `fast()` or `setup()`
 - the user asks for an AllSet route that is not Fast <-> EVM
-- the user asks for AllSet chain names like `ethereum-sepolia` or `arbitrum-sepolia` instead of the shipped chain keys `ethereum` and `arbitrum`
+- the user asks for legacy AllSet testnet chain names `ethereum` or `arbitrum` instead of the shipped chain keys `ethereum-sepolia` and `arbitrum-sepolia`
 - the requested AllSet token is not the shipped `USDC`, `fastUSDC`, or `testUSDC` mapping
 - the request assumes all x402 networks support auto-bridge
 - the request assumes the x402 client network list equals end-to-end server + facilitator support

--- a/references/fast-sdk.md
+++ b/references/fast-sdk.md
@@ -103,7 +103,7 @@ Shared helpers:
   3. bundled defaults
   4. hardcoded fallbacks
 - Browser config omits the `~/.fast/*` layer and uses constructor overrides plus bundled defaults.
-- Built-in token symbols currently resolve `FAST` and `testUSDC` on `testnet`, and `FAST` plus `fastUSDC` on `mainnet`.
+- Built-in token symbols currently resolve `FAST` and `testUSDC` on `testnet`, and `FAST` plus `USDC` on `mainnet`.
 - `wallet.send(...)` expects human-readable amount strings such as `'1.5'`.
 - Fast addresses must be bech32m with `fast` prefix.
 - The native token symbol is `FAST`.

--- a/references/x402-client.md
+++ b/references/x402-client.md
@@ -97,7 +97,7 @@ Provide both wallets to enable auto-bridge:
 wallet: [fastWallet, evmWallet]
 ```
 
-Current bridge helper configs are explicit, not generic. In the shipped helper, only the bundled `base` path resolves an AllSet bridge config today.
+Current bridge helper configs are explicit, not generic. In the shipped helper, bundled bridge configs currently resolve `ethereum-sepolia`, `arbitrum-sepolia`, and `base`.
 
 In production, only provide both wallets after the user confirms the bridge path, source wallet, destination
 network, and spend ceiling. Otherwise pass a single wallet so the payment either succeeds on that network or fails closed.

--- a/references/x402-facilitator.md
+++ b/references/x402-facilitator.md
@@ -53,13 +53,15 @@ Fast payments do not need settlement because the payment is already on-chain.
 - `evmPrivateKey`: required for EVM settlement, because the facilitator pays gas
 - `fastRpcUrl`: optional override for Fast verification
 - `committeePublicKeys`: optional override for trusted Fast committee keys
-- `chains`: declared in the public type, but the current verify / settle path still uses the built-in chain map
+- `chains`: declared in the public type and extends the built-in chain map
 
 ## Supported Networks In Code
 
 EVM:
 
+- `arbitrum-sepolia`
 - `arbitrum`
+- `ethereum-sepolia`
 - `ethereum`
 - `base`
 - `base-sepolia`
@@ -67,8 +69,6 @@ EVM:
 Fast:
 
 - `fast-testnet`, `fast-mainnet`
-
-Hard cutover: `arbitrum-sepolia` and `ethereum-sepolia` are not in the current built-in EVM chain map. `verify(...)` and `settle(...)` return `invalid_network` for them.
 
 ## Operational Rules
 

--- a/references/x402-server.md
+++ b/references/x402-server.md
@@ -84,13 +84,15 @@ This package is not the settlement engine. For working payment verification and 
 
 - The only hard-rejected alias is `fast`. Most other network strings are accepted by the builder.
 - Built-in `NETWORK_CONFIGS` currently resolve concrete asset metadata for:
+  - `fast-testnet`
   - `fast-mainnet`
+  - `arbitrum-sepolia`
   - `arbitrum`
+  - `ethereum-sepolia`
   - `ethereum`
   - `base`
   - `base-sepolia`
 - Any other network name falls back to generic asset `0x0000000000000000000000000000000000000000` with 6 decimals.
-- Hard cutover: do not describe `fast-testnet`, `arbitrum-sepolia`, or `ethereum-sepolia` as turnkey defaults in this package today.
 - Route acceptance still does not guarantee that the facilitator can verify or settle that network.
 
 Use explicit route assets and capability checks when you need anything outside the current built-in config.


### PR DESCRIPTION
## Summary
- switch the routing section in SKILL.md to human-readable relative markdown links
- keep relative doc targets so the GitHub repo remains the source of truth
- add explicit guidance for resolving bundled docs from both installed-skill and skill.fast.xyz entrypoints

## Validation
- npm run validate
- npm run inventory